### PR TITLE
repair the application registerBeanDefinitions read not appropriate c…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Apollo Java 2.1.0
 * [Add a new API to load items with pagination](https://github.com/apolloconfig/apollo/pull/4468)
 * [fix openapi item with url illegalKey 400 error](https://github.com/apolloconfig/apollo/pull/4549)
 * [Add overloaded shortcut method to register BeanDefinition](https://github.com/apolloconfig/apollo/pull/4574)
-* [fix repair the application registerBeanDefinitions read not appropriate configuration](https://github.com/apolloconfig/apollo-java/pull/3)
+* [fix the application registerBeanDefinitions read not appropriate configuration](https://github.com/apolloconfig/apollo-java/pull/3)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/1?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Apollo Java 2.1.0
 * [Add a new API to load items with pagination](https://github.com/apolloconfig/apollo/pull/4468)
 * [fix openapi item with url illegalKey 400 error](https://github.com/apolloconfig/apollo/pull/4549)
 * [Add overloaded shortcut method to register BeanDefinition](https://github.com/apolloconfig/apollo/pull/4574)
+* [fix repair the application registerBeanDefinitions read not appropriate configuration](https://github.com/apolloconfig/apollo-java/pull/3)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/1?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Apollo Java 2.1.0
 * [Add a new API to load items with pagination](https://github.com/apolloconfig/apollo/pull/4468)
 * [fix openapi item with url illegalKey 400 error](https://github.com/apolloconfig/apollo/pull/4549)
 * [Add overloaded shortcut method to register BeanDefinition](https://github.com/apolloconfig/apollo/pull/4574)
-* [fix the application registerBeanDefinitions read not appropriate configuration](https://github.com/apolloconfig/apollo-java/pull/3)
+* [Fix ApolloBootstrapPropertySources precedence issue](https://github.com/apolloconfig/apollo-java/pull/3)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/1?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
@@ -25,6 +25,7 @@ import com.ctrip.framework.apollo.core.utils.DeferredLogger;
 import com.ctrip.framework.apollo.spring.config.CachedCompositePropertySource;
 import com.ctrip.framework.apollo.spring.config.ConfigPropertySourceFactory;
 import com.ctrip.framework.apollo.spring.config.PropertySourcesConstants;
+import com.ctrip.framework.apollo.spring.util.PropertySourcesUtil;
 import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.google.common.base.Splitter;
@@ -119,10 +120,14 @@ public class ApolloApplicationContextInitializer implements
    * @param environment
    */
   protected void initialize(ConfigurableEnvironment environment) {
-
+    final ConfigUtil configUtil = ApolloInjector.getInstance(ConfigUtil.class);
     if (environment.getPropertySources().contains(PropertySourcesConstants.APOLLO_BOOTSTRAP_PROPERTY_SOURCE_NAME)) {
       //already initialized, replay the logs that were printed before the logging system was initialized
       DeferredLogger.replayTo();
+      if (configUtil.isOverrideSystemProperties()) {
+        // ensure ApolloBootstrapPropertySources is still the first
+        PropertySourcesUtil.ensureBootstrapPropertyPrecedence(environment);
+      }
       return;
     }
 
@@ -131,7 +136,6 @@ public class ApolloApplicationContextInitializer implements
     List<String> namespaceList = NAMESPACE_SPLITTER.splitToList(namespaces);
 
     CompositePropertySource composite;
-    final ConfigUtil configUtil = ApolloInjector.getInstance(ConfigUtil.class);
     if (configUtil.isPropertyNamesCacheEnabled()) {
       composite = new CachedCompositePropertySource(PropertySourcesConstants.APOLLO_BOOTSTRAP_PROPERTY_SOURCE_NAME);
     } else {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
@@ -20,8 +20,8 @@ import com.ctrip.framework.apollo.Config;
 import com.ctrip.framework.apollo.ConfigChangeListener;
 import com.ctrip.framework.apollo.ConfigService;
 import com.ctrip.framework.apollo.build.ApolloInjector;
-import com.ctrip.framework.apollo.core.ApolloClientSystemConsts;
 import com.ctrip.framework.apollo.spring.events.ApolloConfigChangeEvent;
+import com.ctrip.framework.apollo.spring.util.PropertySourcesUtil;
 import com.ctrip.framework.apollo.spring.util.SpringInjector;
 import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.google.common.collect.ImmutableSortedSet;
@@ -109,7 +109,7 @@ public class PropertySourcesProcessor implements BeanFactoryPostProcessor, Envir
 
       if (configUtil.isOverrideSystemProperties()) {
         // ensure ApolloBootstrapPropertySources is still the first
-        ensureBootstrapPropertyPrecedence(environment);
+        PropertySourcesUtil.ensureBootstrapPropertyPrecedence(environment);
       }
 
       environment.getPropertySources()
@@ -123,21 +123,6 @@ public class PropertySourcesProcessor implements BeanFactoryPostProcessor, Envir
       }
       environment.getPropertySources().addFirst(composite);
     }
-  }
-
-  private void ensureBootstrapPropertyPrecedence(ConfigurableEnvironment environment) {
-    MutablePropertySources propertySources = environment.getPropertySources();
-
-    PropertySource<?> bootstrapPropertySource = propertySources
-        .get(PropertySourcesConstants.APOLLO_BOOTSTRAP_PROPERTY_SOURCE_NAME);
-
-    // not exists or already in the first place
-    if (bootstrapPropertySource == null || propertySources.precedenceOf(bootstrapPropertySource) == 0) {
-      return;
-    }
-
-    propertySources.remove(PropertySourcesConstants.APOLLO_BOOTSTRAP_PROPERTY_SOURCE_NAME);
-    propertySources.addFirst(bootstrapPropertySource);
   }
 
   private void initializeAutoUpdatePropertiesFeature(ConfigurableListableBeanFactory beanFactory) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/PropertySourcesUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/PropertySourcesUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.spring.util;
+
+import com.ctrip.framework.apollo.spring.config.PropertySourcesConstants;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * @author Gallant
+ */
+public class PropertySourcesUtil {
+
+
+  /**
+   * Ensure ApolloBootstrapPropertySources is still the first
+   * @param environment : Ensure ApolloBootstrapPropertySources is still the first in the environment
+   */
+  public static void ensureBootstrapPropertyPrecedence(ConfigurableEnvironment environment) {
+    MutablePropertySources propertySources = environment.getPropertySources();
+
+    PropertySource<?> bootstrapPropertySource = propertySources
+        .get(PropertySourcesConstants.APOLLO_BOOTSTRAP_PROPERTY_SOURCE_NAME);
+
+    // not exists or already in the first place
+    if (bootstrapPropertySource == null || propertySources.precedenceOf(bootstrapPropertySource) == 0) {
+      return;
+    }
+
+    propertySources.remove(PropertySourcesConstants.APOLLO_BOOTSTRAP_PROPERTY_SOURCE_NAME);
+    propertySources.addFirst(bootstrapPropertySource);
+  }
+
+}


### PR DESCRIPTION
repair the application registerBeanDefinitions read not appropriate configuration

## What's the purpose of this PR

repair the application registerBeanDefinitions read not appropriate configuration,cause apollo config wasn't the first configuration in environment during registerBeanDefinitions to postProcessBeanFactory,when spring.cloud.bootstrap.enabled is set to true

I have verified that this repair works in our project

For details, plz see the blog : http://t.csdn.cn/aI7Q1

## Which issue(s) this PR fixes:
Fixes # no exists issue

## Brief changelog

ApolloApplicationContextInitializer#initialize : When the context has been initialized,also want to add ensureBootstrapPropertyPrecedence processing