### PR TITLE
apollo-client support spring boot 3.0

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -45,6 +45,7 @@ header:
     - 'NOTICE'
     - 'CNAME'
     - '**/resources/META-INF/services/**'
+    - '**/resources/META-INF/spring/**'
     - 'apollo-core/src/test/resources/META-INF/app-with-utf8bom.properties'
     - 'apollo-core/src/test/resources/properties/server-with-utf8bom.properties'
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Apollo Java 2.1.0
 * [fix openapi item with url illegalKey 400 error](https://github.com/apolloconfig/apollo/pull/4549)
 * [Add overloaded shortcut method to register BeanDefinition](https://github.com/apolloconfig/apollo/pull/4574)
 * [Fix ApolloBootstrapPropertySources precedence issue](https://github.com/apolloconfig/apollo-java/pull/3)
+* [Apollo Client Support Spring Boot 3.0](https://github.com/apolloconfig/apollo-java/pull/4)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/1?closed=1)

--- a/apollo-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/apollo-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.ctrip.framework.apollo.spring.boot.ApolloAutoConfiguration


### PR DESCRIPTION
## What's the purpose of this PR

As spring boot 3.0 [deprecated](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files) the auto-configuration support in spring.factories, we need to use the new way to configure it in the `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` to let apollo-client support spring boot 3.0.

## Brief changelog

* add the new file `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` with content `com.ctrip.framework.apollo.spring.boot.ApolloAutoConfiguration`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).
