### PR TITLE
apollo-client-config-data support spring boot 3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Apollo Java 2.1.0
 * [Add overloaded shortcut method to register BeanDefinition](https://github.com/apolloconfig/apollo/pull/4574)
 * [Fix ApolloBootstrapPropertySources precedence issue](https://github.com/apolloconfig/apollo-java/pull/3)
 * [Apollo Client Support Spring Boot 3.0](https://github.com/apolloconfig/apollo-java/pull/4)
+* [apollo-client-config-data support spring boot 3.0](https://github.com/apolloconfig/apollo-java/pull/5)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/1?closed=1)

--- a/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/extension/initialize/ApolloClientExtensionInitializeFactory.java
+++ b/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/extension/initialize/ApolloClientExtensionInitializeFactory.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.Log;
 import org.springframework.boot.ConfigurableBootstrapContext;
 import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.logging.DeferredLogFactory;
 
 /**
  * @author vdisk <vdisk@foxmail.com>
@@ -40,13 +41,15 @@ public class ApolloClientExtensionInitializeFactory {
 
   private final ApolloClientWebsocketExtensionInitializer apolloClientWebsocketExtensionInitializer;
 
-  public ApolloClientExtensionInitializeFactory(Log log,
+  public ApolloClientExtensionInitializeFactory(DeferredLogFactory logFactory,
       ConfigurableBootstrapContext bootstrapContext) {
-    this.log = log;
+    this.log = logFactory.getLog(ApolloClientExtensionInitializeFactory.class);
     this.apolloClientPropertiesFactory = new ApolloClientPropertiesFactory();
-    this.apolloClientLongPollingExtensionInitializer = new ApolloClientLongPollingExtensionInitializer(log,
+    this.apolloClientLongPollingExtensionInitializer = new ApolloClientLongPollingExtensionInitializer(
+        logFactory,
         bootstrapContext);
-    this.apolloClientWebsocketExtensionInitializer = new ApolloClientWebsocketExtensionInitializer(log,
+    this.apolloClientWebsocketExtensionInitializer = new ApolloClientWebsocketExtensionInitializer(
+        logFactory,
         bootstrapContext);
   }
 

--- a/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/extension/webclient/ApolloClientLongPollingExtensionInitializer.java
+++ b/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/extension/webclient/ApolloClientLongPollingExtensionInitializer.java
@@ -27,6 +27,7 @@ import org.apache.commons.logging.Log;
 import org.springframework.boot.ConfigurableBootstrapContext;
 import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.boot.web.reactive.function.client.WebClientCustomizer;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -41,9 +42,9 @@ public class ApolloClientLongPollingExtensionInitializer implements
 
   private final ConfigurableBootstrapContext bootstrapContext;
 
-  public ApolloClientLongPollingExtensionInitializer(Log log,
+  public ApolloClientLongPollingExtensionInitializer(DeferredLogFactory logFactory,
       ConfigurableBootstrapContext bootstrapContext) {
-    this.log = log;
+    this.log = logFactory.getLog(ApolloClientLongPollingExtensionInitializer.class);
     this.bootstrapContext = bootstrapContext;
   }
 

--- a/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/extension/websocket/ApolloClientWebsocketExtensionInitializer.java
+++ b/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/extension/websocket/ApolloClientWebsocketExtensionInitializer.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.springframework.boot.ConfigurableBootstrapContext;
 import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.logging.DeferredLogFactory;
 
 /**
  * @author vdisk <vdisk@foxmail.com>
@@ -32,9 +33,9 @@ public class ApolloClientWebsocketExtensionInitializer implements ApolloClientEx
 
   private final ConfigurableBootstrapContext bootstrapContext;
 
-  public ApolloClientWebsocketExtensionInitializer(Log log,
+  public ApolloClientWebsocketExtensionInitializer(DeferredLogFactory logFactory,
       ConfigurableBootstrapContext bootstrapContext) {
-    this.log = log;
+    this.log = logFactory.getLog(ApolloClientWebsocketExtensionInitializer.class);
     this.bootstrapContext = bootstrapContext;
   }
 

--- a/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/importer/ApolloConfigDataLoader.java
+++ b/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/importer/ApolloConfigDataLoader.java
@@ -34,6 +34,7 @@ import org.springframework.boot.context.config.ConfigDataLoaderContext;
 import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
 import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.PropertySource;
 
@@ -42,10 +43,13 @@ import org.springframework.core.env.PropertySource;
  */
 public class ApolloConfigDataLoader implements ConfigDataLoader<ApolloConfigDataResource>, Ordered {
 
+  private final DeferredLogFactory logFactory;
+
   private final Log log;
 
-  public ApolloConfigDataLoader(Log log) {
-    this.log = log;
+  public ApolloConfigDataLoader(DeferredLogFactory logFactory) {
+    this.logFactory = logFactory;
+    this.log = logFactory.getLog(ApolloConfigDataLoader.class);
   }
 
   @Override
@@ -55,7 +59,7 @@ public class ApolloConfigDataLoader implements ConfigDataLoader<ApolloConfigData
     Binder binder = bootstrapContext.get(Binder.class);
     BindHandler bindHandler = this.getBindHandler(context);
     bootstrapContext.registerIfAbsent(ApolloConfigDataLoaderInitializer.class, InstanceSupplier
-        .from(() -> new ApolloConfigDataLoaderInitializer(this.log, binder, bindHandler,
+        .from(() -> new ApolloConfigDataLoaderInitializer(this.logFactory, binder, bindHandler,
             bootstrapContext)));
     ApolloConfigDataLoaderInitializer apolloConfigDataLoaderInitializer = bootstrapContext
         .get(ApolloConfigDataLoaderInitializer.class);

--- a/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/importer/ApolloConfigDataLoaderInitializer.java
+++ b/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/importer/ApolloConfigDataLoaderInitializer.java
@@ -35,6 +35,7 @@ import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertySource;
 
@@ -45,6 +46,8 @@ class ApolloConfigDataLoaderInitializer {
 
   private static volatile boolean INITIALIZED = false;
 
+  private final DeferredLogFactory logFactory;
+
   private final Log log;
 
   private final Binder binder;
@@ -53,10 +56,11 @@ class ApolloConfigDataLoaderInitializer {
 
   private final ConfigurableBootstrapContext bootstrapContext;
 
-  public ApolloConfigDataLoaderInitializer(Log log,
+  public ApolloConfigDataLoaderInitializer(DeferredLogFactory logFactory,
       Binder binder, BindHandler bindHandler,
       ConfigurableBootstrapContext bootstrapContext) {
-    this.log = log;
+    this.logFactory = logFactory;
+    this.log = logFactory.getLog(ApolloConfigDataLoaderInitializer.class);
     this.binder = binder;
     this.bindHandler = bindHandler;
     this.bootstrapContext = bootstrapContext;
@@ -98,9 +102,9 @@ class ApolloConfigDataLoaderInitializer {
   }
 
   private void initApolloClientInternal() {
-    new ApolloClientSystemPropertyInitializer(this.log)
+    new ApolloClientSystemPropertyInitializer(this.logFactory)
         .initializeSystemProperty(this.binder, this.bindHandler);
-    new ApolloClientExtensionInitializeFactory(this.log,
+    new ApolloClientExtensionInitializeFactory(this.logFactory,
         this.bootstrapContext).initializeExtension(this.binder, this.bindHandler);
     DeferredLogger.enable();
     ApolloConfigDataInjectorCustomizer.register(ConfigFactory.class,

--- a/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/importer/ApolloConfigDataLocationResolver.java
+++ b/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/importer/ApolloConfigDataLocationResolver.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.config.ConfigDataLocationResolver;
 import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
 import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
 import org.springframework.boot.context.config.Profiles;
+import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.core.Ordered;
 import org.springframework.util.StringUtils;
 
@@ -40,8 +41,8 @@ public class ApolloConfigDataLocationResolver implements
 
   private final Log log;
 
-  public ApolloConfigDataLocationResolver(Log log) {
-    this.log = log;
+  public ApolloConfigDataLocationResolver(DeferredLogFactory logFactory) {
+    this.log = logFactory.getLog(ApolloConfigDataLocationResolver.class);
   }
 
   @Override

--- a/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/system/ApolloClientSystemPropertyInitializer.java
+++ b/apollo-client-config-data/src/main/java/com/ctrip/framework/apollo/config/data/system/ApolloClientSystemPropertyInitializer.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -31,8 +32,8 @@ public class ApolloClientSystemPropertyInitializer {
 
   private final Log log;
 
-  public ApolloClientSystemPropertyInitializer(Log log) {
-    this.log = log;
+  public ApolloClientSystemPropertyInitializer(DeferredLogFactory logFactory) {
+    this.log = logFactory.getLog(ApolloClientSystemPropertyInitializer.class);
   }
 
   public void initializeSystemProperty(Binder binder, BindHandler bindHandler) {

--- a/apollo-client-config-data/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/apollo-client-config-data/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.ctrip.framework.apollo.config.data.ApolloClientConfigDataAutoConfiguration

--- a/apollo-client-config-data/src/test/java/com/ctrip/framework/apollo/config/data/system/ApolloClientSystemPropertyInitializerTest.java
+++ b/apollo-client-config-data/src/test/java/com/ctrip/framework/apollo/config/data/system/ApolloClientSystemPropertyInitializerTest.java
@@ -20,7 +20,7 @@ import com.ctrip.framework.apollo.spring.boot.ApolloApplicationContextInitialize
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
-import org.apache.commons.logging.LogFactory;
+import java.util.function.Supplier;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -50,7 +50,7 @@ public class ApolloClientSystemPropertyInitializerTest {
     MapConfigurationPropertySource propertySource = new MapConfigurationPropertySource(map);
     Binder binder = new Binder(propertySource);
     ApolloClientSystemPropertyInitializer initializer = new ApolloClientSystemPropertyInitializer(
-        LogFactory.getLog(ApolloClientSystemPropertyInitializerTest.class));
+        Supplier::get);
     initializer.initializeSystemProperty(binder, null);
     for (String propertyName : ApolloApplicationContextInitializer.APOLLO_SYSTEM_PROPERTIES) {
       Assert.assertEquals(map.get(propertyName), System.getProperty(propertyName));


### PR DESCRIPTION
## What's the purpose of this PR

apollo-client-config-data support spring boot 3.0

## Which issue(s) this PR fixes:
Fixes apolloconfig/apollo#4668

## Brief changelog
Replace `Log` with `DeferredLogFactory`.
The `DeferredLogFactory` is only available in spring boot 2.4.3+, so this PR will drop support for spring boot 2.4.0 ~ 2.4.2

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).
