### PR TITLE
Add Ordered interface to MessageProducerManager and Injector SPI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Apollo Java 2.1.0
 * [Add apollo-plugin-log4j2 module to support log4j2.xml integration](https://github.com/apolloconfig/apollo-java/pull/6)
 * [Allow users to config comma-separated namespaces for ApolloConfigChangeListener](https://github.com/apolloconfig/apollo-java/pull/11)
 * [Fix beanName2SpringValueDefinitions cache issue](https://github.com/apolloconfig/apollo-java/pull/16)
+* [Add Ordered interface to MessageProducerManager and Injector SPI](https://github.com/apolloconfig/apollo-java/pull/15)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/1?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/build/ApolloInjector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/build/ApolloInjector.java
@@ -33,7 +33,7 @@ public class ApolloInjector {
       synchronized (lock) {
         if (s_injector == null) {
           try {
-            s_injector = ServiceBootstrap.loadFirst(Injector.class);
+            s_injector = ServiceBootstrap.loadPrimary(Injector.class);
           } catch (Throwable ex) {
             ApolloConfigException exception = new ApolloConfigException("Unable to initialize Apollo Injector!", ex);
             Tracer.logError(exception);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/Injector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/Injector.java
@@ -16,10 +16,12 @@
  */
 package com.ctrip.framework.apollo.internals;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
+
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
-public interface Injector {
+public interface Injector extends Ordered {
 
   /**
    * Returns the appropriate instance for the given injection type
@@ -30,4 +32,9 @@ public interface Injector {
    * Returns the appropriate instance for the given injection type and name
    */
   <T> T getInstance(Class<T> clazz, String name);
+
+  @Override
+  default int getOrder() {
+    return 0;
+  }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/Tracer.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/Tracer.java
@@ -44,7 +44,7 @@ public abstract class Tracer {
       if (producerManager == null) {
         synchronized (lock) {
           if (producerManager == null) {
-            producerManager = ServiceBootstrap.loadFirst(MessageProducerManager.class);
+            producerManager = ServiceBootstrap.loadPrimary(MessageProducerManager.class);
           }
         }
       }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/spi/MessageProducerManager.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/tracer/spi/MessageProducerManager.java
@@ -16,12 +16,19 @@
  */
 package com.ctrip.framework.apollo.tracer.spi;
 
+import com.ctrip.framework.apollo.core.spi.Ordered;
+
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
-public interface MessageProducerManager {
+public interface MessageProducerManager extends Ordered {
   /**
    * @return the message producer
    */
   MessageProducer getProducer();
+
+  @Override
+  default int getOrder() {
+    return 0;
+  }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/ServiceBootstrap.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/ServiceBootstrap.java
@@ -25,6 +25,10 @@ import java.util.List;
 import java.util.ServiceLoader;
 
 public class ServiceBootstrap {
+
+  /**
+   * @deprecated use {@link ServiceBootstrap#loadPrimary(Class)} instead
+   */
   public static <S> S loadFirst(Class<S> clazz) {
     Iterator<S> iterator = loadAll(clazz);
     if (!iterator.hasNext()) {


### PR DESCRIPTION
## What's the purpose of this PR

Add Ordered interface to MessageProducerManager and Injector SPI

## Which issue(s) this PR fixes:
Fixes https://github.com/apolloconfig/apollo/issues/4699

## Brief changelog

* Add Ordered interface to MessageProducerManager and Injector SPI
* Deprecate ServiceBootstrap.loadFirst method

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).
