### PR TITLE
Fix beanName2SpringValueDefinitions cache issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,5 +17,7 @@ Apollo Java 2.1.0
 * [apollo-client-config-data support spring boot 3.0](https://github.com/apolloconfig/apollo-java/pull/5)
 * [Add apollo-plugin-log4j2 module to support log4j2.xml integration](https://github.com/apolloconfig/apollo-java/pull/6)
 * [Allow users to config comma-separated namespaces for ApolloConfigChangeListener](https://github.com/apolloconfig/apollo-java/pull/11)
+* [Fix beanName2SpringValueDefinitions cache issue](https://github.com/apolloconfig/apollo-java/pull/16)
+
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/1?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringValueDefinitionProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringValueDefinitionProcessor.java
@@ -73,10 +73,8 @@ public class SpringValueDefinitionProcessor implements BeanDefinitionRegistryPos
   }
 
   public static Multimap<String, SpringValueDefinition> getBeanName2SpringValueDefinitions(BeanDefinitionRegistry registry) {
-    Multimap<String, SpringValueDefinition> springValueDefinitions = beanName2SpringValueDefinitions.get(registry);
-    if (springValueDefinitions == null) {
-      springValueDefinitions = LinkedListMultimap.create();
-    }
+    Multimap<String, SpringValueDefinition> springValueDefinitions = beanName2SpringValueDefinitions.computeIfAbsent(
+        registry, k -> LinkedListMultimap.create());
 
     return springValueDefinitions;
   }


### PR DESCRIPTION
## What's the purpose of this PR

Fix beanName2SpringValueDefinitions cache issue

## Which issue(s) this PR fixes:
Fixes #13

## Brief changelog

* use computeIfAbsent method

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).
