### PR TITLE
refactor(apollo-client): Optimize the exception message when failing to retrieve configuration information.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,6 @@ Release Notes.
 Apollo Java 2.2.0
 
 ------------------
-
+[refactor(apollo-client): Optimize the exception message when failing to retrieve configuration information.](https://github.com/apolloconfig/apollo-java/pull/22)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/2?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ExceptionUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ExceptionUtil.java
@@ -53,7 +53,7 @@ public class ExceptionUtil {
         continue;
       }
       builder.append(" [Cause: ")
-              .append(getThrowingClassName(cause))
+              .append(cause.getClass().getSimpleName())
               .append("(")
               .append(cause.getMessage())
               .append(")");
@@ -64,7 +64,4 @@ public class ExceptionUtil {
     return builder.toString();
   }
 
-  public static String getThrowingClassName(Throwable throwable) {
-    return throwable.getClass().getSimpleName();
-  }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ExceptionUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ExceptionUtil.java
@@ -52,11 +52,19 @@ public class ExceptionUtil {
         counter--;
         continue;
       }
-      builder.append(" [Cause: ").append(cause.getMessage());
+      builder.append(" [Cause: ")
+              .append(getThrowingClassName(cause))
+              .append("(")
+              .append(cause.getMessage())
+              .append(")");
     }
 
     builder.append(Strings.repeat("]", counter));
 
     return builder.toString();
+  }
+
+  public static String getThrowingClassName(Throwable throwable) {
+    return throwable.getClass().getSimpleName();
   }
 }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/util/ExceptionUtilTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/util/ExceptionUtilTest.java
@@ -38,11 +38,11 @@ public class ExceptionUtilTest {
     String causeMsg2 = "another cause";
     String someMessage = "some message";
 
-    Throwable cause2 = new Throwable(causeMsg2);
+    Throwable cause2 = new Exception(causeMsg2);
     Throwable cause1 = new Throwable(causeMsg1, cause2);
     Throwable ex = new Throwable(someMessage, cause1);
 
-    String expected = someMessage + " [Cause: " + causeMsg1 + " [Cause: " + causeMsg2 + "]]";
+    String expected = someMessage + " [Cause: Throwable("+ causeMsg1 +") [Cause: Exception(" + causeMsg2 + ")]]";
     assertEquals(expected, ExceptionUtil.getDetailMessage(ex));
   }
 


### PR DESCRIPTION
## What's the purpose of this PR
In a k8s environment, when configuration retrieval fails due to certain issues, the current exception message is not sufficient for troubleshooting, such as the following exception:
`
 reason: Load Apollo Config failed - appId: infra-tconfig, cluster: default, namespace: application, url: http://apollo-service-dev-apollo-configservice.apollo:8080/configs/infra-tconfig/default/application?ip=172.26.203.126 [Cause: Could not complete get operation [Cause: apollo-service-dev-apollo-configservice.apollo.]]
`

Finally, it was found that the issue was caused by unstable DNS resolution. The updated exception message will provide this critical information, such as:
`
reason: Load Apollo Config failed - appId: infra-tconfig, cluster: default, namespace: application, url: http://apollo-service-dev-apollo-configservice.apollo.:8080/configs/infra-tconfig/default/application?ip=172.26.203.126 [Cause: ApolloConfigException(Could not complete get operation) [Cause: UnknownHostException(apollo-service-dev-apollo-configservice.apollo.)]]
`
