### PR TITLE
Support concurrent loading of Config for different namespaces (#29)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,5 +7,6 @@ Apollo Java 2.2.0
 ------------------
 [refactor(apollo-client): Optimize the exception message when failing to retrieve configuration information.](https://github.com/apolloconfig/apollo-java/pull/22)
 [Add JUnit5 extension support for apollo mock server.](https://github.com/apolloconfig/apollo-java/pull/25)
+[Support concurrent loading of Config for different namespaces.](https://github.com/apolloconfig/apollo-java/pull/31)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/2?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfigManager.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfigManager.java
@@ -33,7 +33,9 @@ public class DefaultConfigManager implements ConfigManager {
   private ConfigFactoryManager m_factoryManager;
 
   private Map<String, Config> m_configs = Maps.newConcurrentMap();
+  private Map<String, Object> m_configLocks = Maps.newConcurrentMap();
   private Map<String, ConfigFile> m_configFiles = Maps.newConcurrentMap();
+  private Map<String, Object> m_configFileLocks = Maps.newConcurrentMap();
 
   public DefaultConfigManager() {
     m_factoryManager = ApolloInjector.getInstance(ConfigFactoryManager.class);
@@ -44,7 +46,8 @@ public class DefaultConfigManager implements ConfigManager {
     Config config = m_configs.get(namespace);
 
     if (config == null) {
-      synchronized (this) {
+      Object lock = m_configLocks.computeIfAbsent(namespace, key -> new Object());
+      synchronized (lock) {
         config = m_configs.get(namespace);
 
         if (config == null) {
@@ -65,7 +68,8 @@ public class DefaultConfigManager implements ConfigManager {
     ConfigFile configFile = m_configFiles.get(namespaceFileName);
 
     if (configFile == null) {
-      synchronized (this) {
+      Object lock = m_configFileLocks.computeIfAbsent(namespaceFileName, key -> new Object());
+      synchronized (lock) {
         configFile = m_configFiles.get(namespaceFileName);
 
         if (configFile == null) {


### PR DESCRIPTION
## What's the purpose of this PR

fix #29 

## Which issue(s) this PR fixes:
Fixes #29 

## Brief changelog

* Support concurrent loading of Config for different namespaces.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).
