### PR TITLE
fix: compatible with snakeyaml-2.0

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/yaml/YamlParser.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/yaml/YamlParser.java
@@ -67,7 +67,9 @@ public class YamlParser {
   private Yaml createYaml() {
     LoaderOptions loadingConfig = new LoaderOptions();
     loadingConfig.setAllowDuplicateKeys(false);
-    return new Yaml(new SafeConstructor(), new Representer(), new DumperOptions(), loadingConfig);
+    DumperOptions dumperOptions = new DumperOptions();
+    return new Yaml(new SafeConstructor(loadingConfig),
+            new Representer(dumperOptions), dumperOptions, loadingConfig);
   }
 
   private boolean process(MatchCallback callback, Yaml yaml, String content) {


### PR DESCRIPTION
## What's the purpose of this PR

since snakeyaml-2.0 has remove empty args constructor, we need use the constructor with options 
## Which issue(s) this PR fixes:
Fixes # https://github.com/apolloconfig/apollo/issues/4960

## Brief changelog
```
-    return new Yaml(new SafeConstructor(), new Representer(), new DumperOptions(), loadingConfig);
+   DumperOptions dumperOptions = new DumperOptions();
+   return new Yaml(new SafeConstructor(loadingConfig),
            new Representer(dumperOptions), dumperOptions, loadingConfig);
```

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).
