### PR TITLE
fix: compatible with snakeyaml-2.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,5 +8,6 @@ Apollo Java 2.2.0
 [refactor(apollo-client): Optimize the exception message when failing to retrieve configuration information.](https://github.com/apolloconfig/apollo-java/pull/22)
 [Add JUnit5 extension support for apollo mock server.](https://github.com/apolloconfig/apollo-java/pull/25)
 [Support concurrent loading of Config for different namespaces.](https://github.com/apolloconfig/apollo-java/pull/31)
+[Fix snakeyaml 2.x compatibility issues](https://github.com/apolloconfig/apollo-java/pull/35)
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/2?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/yaml/YamlParser.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/yaml/YamlParser.java
@@ -67,7 +67,9 @@ public class YamlParser {
   private Yaml createYaml() {
     LoaderOptions loadingConfig = new LoaderOptions();
     loadingConfig.setAllowDuplicateKeys(false);
-    return new Yaml(new SafeConstructor(), new Representer(), new DumperOptions(), loadingConfig);
+    DumperOptions dumperOptions = new DumperOptions();
+    return new Yaml(new SafeConstructor(loadingConfig),
+            new Representer(dumperOptions), dumperOptions, loadingConfig);
   }
 
   private boolean process(MatchCallback callback, Yaml yaml, String content) {


### PR DESCRIPTION
## What's the purpose of this PR

since snakeyaml-2.x has removed empty args constructor, we need use the constructor with options


## Which issue(s) this PR fixes:
Fixes #
https://github.com/apolloconfig/apollo/issues/4960

## Brief changelog
```diff
-    return new Yaml(new SafeConstructor(), new Representer(), new DumperOptions(), loadingConfig);
+   DumperOptions dumperOptions = new DumperOptions();
+   return new Yaml(new SafeConstructor(loadingConfig),
            new Representer(dumperOptions), dumperOptions, loadingConfig);
```
Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).
