### PR TITLE
Implement parsing time based on pattern for @ApolloJsonValue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Apollo Java 2.3.0
 
 ------------------
 * [add an initialize method to avoid DefaultProviderManager's logic being triggered when using custom ProviderManager.](https://github.com/apolloconfig/apollo-java/pull/50)
-* [Implement parsing time based on pattern for @ApolloJsonValue](https://github.com/apolloconfig/apollo-java/pull/52)
+* [Implement parsing time based on pattern for @ApolloJsonValue](https://github.com/apolloconfig/apollo-java/pull/53)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/3?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Release Notes.
 Apollo Java 2.3.0
 
 ------------------
-* 
+* [Implement parsing time based on pattern for @ApolloJsonValue](https://github.com/apolloconfig/apollo-java/pull/52)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/3?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
@@ -34,10 +34,10 @@ import com.google.gson.Gson;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 
 import com.google.gson.GsonBuilder;
@@ -66,7 +66,7 @@ public class ApolloAnnotationProcessor extends ApolloProcessor implements BeanFa
 
   private static final Splitter NAMESPACE_SPLITTER = Splitter.on(NAMESPACE_DELIMITER)
       .omitEmptyStrings().trimResults();
-  private static final Map<String, Gson> DATEPATTERN_GSON_MAP = new HashMap<>();
+  private static final Map<String, Gson> DATEPATTERN_GSON_MAP = new ConcurrentHashMap<>();
 
   private final ConfigUtil configUtil;
   private final PlaceholderHelper placeholderHelper;

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
@@ -191,7 +191,7 @@ public class ApolloAnnotationProcessor extends ApolloProcessor implements BeanFa
     boolean accessible = field.isAccessible();
     field.setAccessible(true);
     ReflectionUtils
-            .setField(field, bean, parseJsonValue((String) propertyValue, field.getGenericType(), datePattern));
+        .setField(field, bean, parseJsonValue((String) propertyValue, field.getGenericType(), datePattern));
     field.setAccessible(accessible);
 
     if (configUtil.isAutoUpdateInjectedSpringPropertiesEnabled()) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloAnnotationProcessor.java
@@ -20,6 +20,7 @@ import com.ctrip.framework.apollo.Config;
 import com.ctrip.framework.apollo.ConfigChangeListener;
 import com.ctrip.framework.apollo.ConfigService;
 import com.ctrip.framework.apollo.build.ApolloInjector;
+import com.ctrip.framework.apollo.core.utils.StringUtils;
 import com.ctrip.framework.apollo.model.ConfigChangeEvent;
 import com.ctrip.framework.apollo.spring.property.PlaceholderHelper;
 import com.ctrip.framework.apollo.spring.property.SpringValue;
@@ -252,11 +253,18 @@ public class ApolloAnnotationProcessor extends ApolloProcessor implements BeanFa
 
   private Object parseJsonValue(String json, Type targetType, String datePattern) {
     try {
-      return DATEPATTERN_GSON_MAP.computeIfAbsent(datePattern, (pattern) -> new GsonBuilder().setDateFormat(pattern).create()).fromJson(json, targetType);
+      return DATEPATTERN_GSON_MAP.computeIfAbsent(datePattern, this::buildGson).fromJson(json, targetType);
     } catch (Throwable ex) {
       logger.error("Parsing json '{}' to type {} failed!", json, targetType, ex);
       throw ex;
     }
+  }
+
+  private Gson buildGson(String datePattern) {
+    if (StringUtils.isBlank(datePattern)) {
+      return new Gson();
+    }
+    return new GsonBuilder().setDateFormat(datePattern).create();
   }
 
   @Override

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloJsonValue.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloJsonValue.java
@@ -32,6 +32,10 @@ import java.lang.annotation.Target;
  * // in Apollo is someJsonPropertyKey={"someString":"someValue", "someInt":10}.
  * &#064;ApolloJsonValue("${someJsonPropertyKey:someDefaultValue}")
  * private SomeObject someObject;
+ * // Suppose SomeObject has a field of type Date named 'time', then the possible config
+ * // in Apollo is someJsonPropertyKey={"time":"2024/01/04"}.
+ * &#064;ApolloJsonValue(value="${someJsonPropertyKey:someDefaultValue}", datePattern="yyyy/MM/dd")
+ * private SomeObject someObject;
  * </pre>
  *
  * Create by zhangzheng on 2018/3/6
@@ -47,4 +51,9 @@ public @interface ApolloJsonValue {
    * The actual value expression: e.g. "${someJsonPropertyKey:someDefaultValue}".
    */
   String value();
+
+  /**
+   * The datePattern follows the same rule as required by {@link java.text.SimpleDateFormat}.
+   */
+  String datePattern() default "";
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoUpdateConfigChangeListener.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoUpdateConfigChangeListener.java
@@ -28,11 +28,11 @@ import com.google.gson.Gson;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 import com.google.gson.GsonBuilder;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -65,7 +65,7 @@ public class AutoUpdateConfigChangeListener implements ConfigChangeListener,
     this.typeConverterHasConvertIfNecessaryWithFieldParameter = testTypeConverterHasConvertIfNecessaryWithFieldParameter();
     this.placeholderHelper = SpringInjector.getInstance(PlaceholderHelper.class);
     this.springValueRegistry = SpringInjector.getInstance(SpringValueRegistry.class);
-    this.datePatternGsonMap = new HashMap<>();
+    this.datePatternGsonMap = new ConcurrentHashMap<>();
     this.configUtil = ApolloInjector.getInstance(ConfigUtil.class);
   }
 
@@ -114,7 +114,7 @@ public class AutoUpdateConfigChangeListener implements ConfigChangeListener,
 
     if (springValue.isJson()) {
       ApolloJsonValue apolloJsonValue = springValue.getField().getAnnotation(ApolloJsonValue.class);
-      String datePattern = apolloJsonValue != null ? apolloJsonValue.datePattern() : "";
+      String datePattern = apolloJsonValue != null ? apolloJsonValue.datePattern() : StringUtils.EMPTY;
       value = parseJsonValue((String) value, springValue.getGenericType(), datePattern);
     } else {
       if (springValue.isField()) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoUpdateConfigChangeListener.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoUpdateConfigChangeListener.java
@@ -18,6 +18,7 @@ package com.ctrip.framework.apollo.spring.property;
 
 import com.ctrip.framework.apollo.ConfigChangeListener;
 import com.ctrip.framework.apollo.build.ApolloInjector;
+import com.ctrip.framework.apollo.core.utils.StringUtils;
 import com.ctrip.framework.apollo.model.ConfigChangeEvent;
 import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValue;
 import com.ctrip.framework.apollo.spring.events.ApolloConfigChangeEvent;
@@ -135,12 +136,18 @@ public class AutoUpdateConfigChangeListener implements ConfigChangeListener,
 
   private Object parseJsonValue(String json, Type targetType, String datePattern) {
     try {
-      return datePatternGsonMap.computeIfAbsent(datePattern, (pattern) -> new GsonBuilder().setDateFormat(datePattern).create())
-              .fromJson(json, targetType);
+      return datePatternGsonMap.computeIfAbsent(datePattern, this::buildGson).fromJson(json, targetType);
     } catch (Throwable ex) {
       logger.error("Parsing json '{}' to type {} failed!", json, targetType, ex);
       throw ex;
     }
+  }
+
+  private Gson buildGson(String datePattern) {
+    if (StringUtils.isBlank(datePattern)) {
+      return new Gson();
+    }
+    return new GsonBuilder().setDateFormat(datePattern).create();
   }
 
   private boolean testTypeConverterHasConvertIfNecessaryWithFieldParameter() {

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderAutoUpdateTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderAutoUpdateTest.java
@@ -873,7 +873,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(someDate, bean.getDateProperty());
     assertEquals("astring", bean.getJsonBeanList().get(0).getA());
     assertEquals(10, bean.getJsonBeanList().get(0).getB());
-    assertNotNull(bean.getJsonDateBean().getStartTime());
+    assertEquals("2024-01-20 00:00:00.000", simpleDateFormat.format(bean.getJsonDateBean().getStartTime()));
 
     Properties newProperties = new Properties();
     newProperties.setProperty("intProperty", String.valueOf(someNewInt));
@@ -906,7 +906,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(someNewDate, bean.getDateProperty());
     assertEquals("newString", bean.getJsonBeanList().get(0).getA());
     assertEquals(20, bean.getJsonBeanList().get(0).getB());
-    assertNotNull(bean.getJsonDateBean().getStartTime());
+    assertEquals("2024-02-21 00:00:00.000", simpleDateFormat.format(bean.getJsonDateBean().getStartTime()));
   }
 
   @Test

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderAutoUpdateTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderAutoUpdateTest.java
@@ -18,6 +18,7 @@ package com.ctrip.framework.apollo.spring;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.ctrip.framework.apollo.build.MockInjector;
@@ -25,6 +26,7 @@ import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.internals.SimpleConfig;
 import com.ctrip.framework.apollo.internals.YamlConfigFile;
 import com.ctrip.framework.apollo.spring.JavaConfigPlaceholderTest.JsonBean;
+import com.ctrip.framework.apollo.spring.JavaConfigPlaceholderTest.JsonDateBean;
 import com.ctrip.framework.apollo.spring.XmlConfigPlaceholderTest.TestXmlBean;
 import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValue;
 import com.ctrip.framework.apollo.spring.annotation.EnableApolloConfig;
@@ -830,6 +832,8 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     String someNewString = "someNewString";
     String someJsonProperty = "[{\"a\":\"astring\", \"b\":10},{\"a\":\"astring2\", \"b\":20}]";
     String someNewJsonProperty = "[{\"a\":\"newString\", \"b\":20},{\"a\":\"astring2\", \"b\":20}]";
+    String someJsonDateProperty = "{\"startTime\":\"2024/01/20\",\"endTime\":\"2024/01/20\"}";;
+    String someNewJsonDateProperty = "{\"startTime\":\"2024/02/21\",\"endTime\":\"2024/02/21\"}";;
 
     String someDateFormat = "yyyy-MM-dd HH:mm:ss.SSS";
     Date someDate = assembleDate(2018, 2, 23, 20, 1, 2, 123);
@@ -849,6 +853,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     properties.setProperty("dateFormat", someDateFormat);
     properties.setProperty("dateProperty", simpleDateFormat.format(someDate));
     properties.setProperty("jsonProperty", someJsonProperty);
+    properties.setProperty("jsonDateProperty", someJsonDateProperty);
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
 
@@ -868,6 +873,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(someDate, bean.getDateProperty());
     assertEquals("astring", bean.getJsonBeanList().get(0).getA());
     assertEquals(10, bean.getJsonBeanList().get(0).getB());
+    assertNotNull(bean.getJsonDateBean().getStartTime());
 
     Properties newProperties = new Properties();
     newProperties.setProperty("intProperty", String.valueOf(someNewInt));
@@ -882,6 +888,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     newProperties.setProperty("dateFormat", someDateFormat);
     newProperties.setProperty("dateProperty", simpleDateFormat.format(someNewDate));
     newProperties.setProperty("jsonProperty", someNewJsonProperty);
+    newProperties.setProperty("jsonDateProperty", someNewJsonDateProperty);
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
@@ -899,6 +906,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(someNewDate, bean.getDateProperty());
     assertEquals("newString", bean.getJsonBeanList().get(0).getA());
     assertEquals(20, bean.getJsonBeanList().get(0).getB());
+    assertNotNull(bean.getJsonDateBean().getStartTime());
   }
 
   @Test
@@ -1311,6 +1319,9 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     @ApolloJsonValue("${jsonProperty}")
     private List<JsonBean> jsonBeanList;
 
+    @ApolloJsonValue(value = "${jsonDateProperty}", datePattern = "yyyy/MM/dd")
+    private JsonDateBean jsonDateBean;
+
     public int getIntProperty() {
       return intProperty;
     }
@@ -1353,6 +1364,10 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     public List<JsonBean> getJsonBeanList() {
       return jsonBeanList;
+    }
+
+    public JsonDateBean getJsonDateBean() {
+      return jsonDateBean;
     }
   }
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderTest.java
@@ -28,8 +28,10 @@ import com.ctrip.framework.apollo.PropertiesCompatibleConfigFile;
 import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValue;
 import com.ctrip.framework.apollo.spring.annotation.EnableApolloConfig;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -396,6 +398,9 @@ public class JavaConfigPlaceholderTest extends AbstractSpringIntegrationTest {
     String dateFormatJson2 = "{\"startTime\":\"2024-01-20T16:51:48\",\"endTime\":\"2024-01-20T16:51:48\"}";
     String dateFormatJson3 = "{\"startTime\":\"2024/01/20\",\"endTime\":\"2024/01/20\"}";
 
+    String someDateFormat = "yyyy-MM-dd HH:mm:ss.SSS";
+    SimpleDateFormat simpleDateFormat = new SimpleDateFormat(someDateFormat, Locale.US);
+
     Config config = mock(Config.class);
     when(config.getProperty(eq(DATE_FORMAT_JSON_PROPERTY1), Mockito.nullable(String.class))).thenReturn(dateFormatJson1);
     when(config.getProperty(eq(DATE_FORMAT_JSON_PROPERTY2), Mockito.nullable(String.class))).thenReturn(dateFormatJson2);
@@ -406,9 +411,9 @@ public class JavaConfigPlaceholderTest extends AbstractSpringIntegrationTest {
         AppConfig12.class);
 
     TestJsonDatePropertyBean datePropertyBean = context.getBean(TestJsonDatePropertyBean.class);
-    assertNotNull(datePropertyBean.getPattern1());
-    assertNotNull(datePropertyBean.getPattern2());
-    assertNotNull(datePropertyBean.getPattern3());
+    assertEquals("2024-01-20 00:00:00.000", simpleDateFormat.format(datePropertyBean.getPattern1().getStartTime()));
+    assertEquals("2024-01-20 16:51:48.000", simpleDateFormat.format(datePropertyBean.getPattern2().getStartTime()));
+    assertEquals("2024-01-20 00:00:00.000", simpleDateFormat.format(datePropertyBean.getPattern3().getStartTime()));
   }
 
   @Test(expected = BeanCreationException.class)

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderTest.java
@@ -17,6 +17,7 @@
 package com.ctrip.framework.apollo.spring;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -27,6 +28,7 @@ import com.ctrip.framework.apollo.PropertiesCompatibleConfigFile;
 import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValue;
 import com.ctrip.framework.apollo.spring.annotation.EnableApolloConfig;
+import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 import org.junit.Test;
@@ -53,6 +55,9 @@ public class JavaConfigPlaceholderTest extends AbstractSpringIntegrationTest {
   private static final String FX_APOLLO_NAMESPACE = "FX.apollo";
   private static final String JSON_PROPERTY = "jsonProperty";
   private static final String OTHER_JSON_PROPERTY = "otherJsonProperty";
+  private static final String DATE_FORMAT_JSON_PROPERTY1 = "jsonDateProperty1";
+  private static final String DATE_FORMAT_JSON_PROPERTY2 = "jsonDateProperty2";
+  private static final String DATE_FORMAT_JSON_PROPERTY3 = "jsonDateProperty3";
 
   @Test
   public void testPropertySourceWithNoNamespace() throws Exception {
@@ -385,6 +390,27 @@ public class JavaConfigPlaceholderTest extends AbstractSpringIntegrationTest {
     assertEquals(20, testJsonPropertyBean.getOtherJsonBeanList().get(1).getB());
   }
 
+  @Test
+  public void testApolloDateJsonValue() {
+    String dateFormatJson1 = "{\"startTime\":\"2024-01-20\",\"endTime\":\"2024-01-20\"}";
+    String dateFormatJson2 = "{\"startTime\":\"2024-01-20T16:51:48\",\"endTime\":\"2024-01-20T16:51:48\"}";
+    String dateFormatJson3 = "{\"startTime\":\"2024/01/20\",\"endTime\":\"2024/01/20\"}";
+
+    Config config = mock(Config.class);
+    when(config.getProperty(eq(DATE_FORMAT_JSON_PROPERTY1), Mockito.nullable(String.class))).thenReturn(dateFormatJson1);
+    when(config.getProperty(eq(DATE_FORMAT_JSON_PROPERTY2), Mockito.nullable(String.class))).thenReturn(dateFormatJson2);
+    when(config.getProperty(eq(DATE_FORMAT_JSON_PROPERTY3), Mockito.nullable(String.class))).thenReturn(dateFormatJson3);
+    mockConfig(ConfigConsts.NAMESPACE_APPLICATION, config);
+
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+        AppConfig12.class);
+
+    TestJsonDatePropertyBean datePropertyBean = context.getBean(TestJsonDatePropertyBean.class);
+    assertNotNull(datePropertyBean.getPattern1());
+    assertNotNull(datePropertyBean.getPattern2());
+    assertNotNull(datePropertyBean.getPattern3());
+  }
+
   @Test(expected = BeanCreationException.class)
   public void testApolloJsonValueWithInvalidJson() throws Exception {
     String someInvalidJson = "someInvalidJson";
@@ -521,6 +547,15 @@ public class JavaConfigPlaceholderTest extends AbstractSpringIntegrationTest {
     @Bean
     TestJavaConfigBean testJavaConfigBean() {
       return new TestJavaConfigBean();
+    }
+  }
+
+  @Configuration
+  @EnableApolloConfig
+  static class AppConfig12 {
+    @Bean
+    TestJsonDatePropertyBean testJsonDatePropertyBean() {
+      return new TestJsonDatePropertyBean();
     }
   }
 
@@ -670,6 +705,59 @@ public class JavaConfigPlaceholderTest extends AbstractSpringIntegrationTest {
       int result = a != null ? a.hashCode() : 0;
       result = 31 * result + b;
       return result;
+    }
+  }
+
+  static class TestJsonDatePropertyBean {
+
+    @ApolloJsonValue(value = "${jsonDateProperty1}", datePattern = "yyyy-MM-dd")
+    private JsonDateBean pattern1;
+
+    @ApolloJsonValue(value = "${jsonDateProperty2}", datePattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private JsonDateBean pattern2;
+
+    @ApolloJsonValue(value = "${jsonDateProperty3}", datePattern = "yyy/MM/dd")
+    private JsonDateBean pattern3;
+
+    public JsonDateBean getPattern1() {
+      return pattern1;
+    }
+
+    public JsonDateBean getPattern2() {
+      return pattern2;
+    }
+
+    public JsonDateBean getPattern3() {
+      return pattern3;
+    }
+  }
+
+  static class JsonDateBean {
+    private Date startTime;
+    private Date endTime;
+
+    public Date getStartTime() {
+      return startTime;
+    }
+
+    public void setStartTime(Date startTime) {
+      this.startTime = startTime;
+    }
+
+    public Date getEndTime() {
+      return endTime;
+    }
+
+    public void setEndTime(Date endTime) {
+      this.endTime = endTime;
+    }
+
+    @Override
+    public String toString() {
+      return "JsonDateBean{" +
+          "startTime=" + startTime +
+          ", endTime=" + endTime +
+          '}';
     }
   }
 }


### PR DESCRIPTION
## What's the purpose of this PR
Implement parsing time based on pattern for @ApolloJsonValue from #49

## Which issue(s) this PR fixes:
Fixes #49 

## Brief changelog

Make use of Gson's current way of turning a string into a date to make @ApolloJsonValue able to handle time strings according to a given pattern.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).
