### PR TITLE
fixed #56 for JUnit5 integration

### DIFF
--- a/apollo-mockserver/src/main/java/com/ctrip/framework/apollo/mockserver/ApolloTestingServer.java
+++ b/apollo-mockserver/src/main/java/com/ctrip/framework/apollo/mockserver/ApolloTestingServer.java
@@ -44,7 +44,7 @@ import java.util.Set;
 
 public class ApolloTestingServer implements AutoCloseable {
 
-    private static final Logger logger = LoggerFactory.getLogger(EmbeddedApollo.class);
+    private static final Logger logger = LoggerFactory.getLogger(ApolloTestingServer.class);
     private static final Type notificationType = new TypeToken<List<ApolloConfigNotification>>() {
     }.getType();
 


### PR DESCRIPTION
## What's the purpose of this PR

Avoid mockserver MockApolloExtension in JUnit5 way forcely denpend on JUnit4.

## Which issue(s) this PR fixes:
Fixes #56 

## Brief changelog

Avoid mockserver MockApolloExtension in JUnit5 way forcely denpend on JUnit4.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated logger declaration for consistency in `ApolloTestingServer`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->