### PR TITLE
perf: speed up the first loading of namespace when startup meet 404

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Apollo Java 2.3.0
 * [add an initialize method to avoid DefaultProviderManager's logic being triggered when using custom ProviderManager.](https://github.com/apolloconfig/apollo-java/pull/50)
 * [Implement parsing time based on pattern for @ApolloJsonValue](https://github.com/apolloconfig/apollo-java/pull/53)
 * [Enhance to load mocked properties from apollo.cache-dir](https://github.com/apolloconfig/apollo-java/pull/58)
+* [perf: speed up the first loading of namespace when startup meet 404](https://github.com/apolloconfig/apollo-java/pull/61)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/3?closed=1)

--- a/apollo-client/pom.xml
+++ b/apollo-client/pom.xml
@@ -92,6 +92,11 @@
 			<artifactId>log4j-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mock-server</groupId>
+			<artifactId>mockserver-netty</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<!-- end of test -->
 	</dependencies>
 </project>

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigRepository.java
@@ -73,4 +73,9 @@ public abstract class AbstractConfigRepository implements ConfigRepository {
       }
     }
   }
+
+  @Override
+  public void initialize() {
+    this.sync();
+  }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigRepository.java
@@ -57,5 +57,5 @@ public interface ConfigRepository {
   /**
    * Initialize the repository.
    */
-  void initialize();
+  default void initialize() {}
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigRepository.java
@@ -53,4 +53,9 @@ public interface ConfigRepository {
    * @return the config's source type
    */
   ConfigSourceType getSourceType();
+
+  /**
+   * Initialize the repository.
+   */
+  void initialize();
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
@@ -71,6 +71,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
 
   private void initialize() {
     try {
+      m_configRepository.initialize();
       updateConfig(m_configRepository.getConfig(), m_configRepository.getSourceType());
     } catch (Throwable ex) {
       Tracer.logError(ex);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepository.java
@@ -71,7 +71,7 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
     m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
     this.setLocalCacheDir(findLocalCacheDir(), false);
     this.setUpstreamRepository(upstream);
-    this.trySync();
+    // this.trySync();
   }
 
   void setLocalCacheDir(File baseDir, boolean syncImmediately) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepository.java
@@ -71,7 +71,6 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
     m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
     this.setLocalCacheDir(findLocalCacheDir(), false);
     this.setUpstreamRepository(upstream);
-    // this.trySync();
   }
 
   void setLocalCacheDir(File baseDir, boolean syncImmediately) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
@@ -104,9 +104,13 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
     m_configNeedForceRefresh = new AtomicBoolean(true);
     m_loadConfigFailSchedulePolicy = new ExponentialSchedulePolicy(m_configUtil.getOnErrorRetryInterval(),
         m_configUtil.getOnErrorRetryInterval() * 8);
-    // this.trySync();
+  }
+
+  @Override
+  public void initialize() {
     this.schedulePeriodicRefresh();
     this.scheduleLongPollingRefresh();
+    super.initialize();
   }
 
   @Override

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
@@ -104,7 +104,7 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
     m_configNeedForceRefresh = new AtomicBoolean(true);
     m_loadConfigFailSchedulePolicy = new ExponentialSchedulePolicy(m_configUtil.getOnErrorRetryInterval(),
         m_configUtil.getOnErrorRetryInterval() * 8);
-    this.trySync();
+    // this.trySync();
     this.schedulePeriodicRefresh();
     this.scheduleLongPollingRefresh();
   }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
@@ -104,13 +104,8 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
     m_configNeedForceRefresh = new AtomicBoolean(true);
     m_loadConfigFailSchedulePolicy = new ExponentialSchedulePolicy(m_configUtil.getOnErrorRetryInterval(),
         m_configUtil.getOnErrorRetryInterval() * 8);
-  }
-
-  @Override
-  public void initialize() {
     this.schedulePeriodicRefresh();
     this.scheduleLongPollingRefresh();
-    super.initialize();
   }
 
   @Override

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/BaseIntegrationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/BaseIntegrationTest.java
@@ -18,34 +18,19 @@ package com.ctrip.framework.apollo;
 
 import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.core.MetaDomainConsts;
+import com.ctrip.framework.apollo.core.dto.ApolloConfig;
+import com.ctrip.framework.apollo.core.dto.ServiceDTO;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.AbstractHandler;
-import org.eclipse.jetty.server.handler.ContextHandler;
-import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.junit.After;
-import org.junit.Before;
 
 import com.ctrip.framework.apollo.build.MockInjector;
-import com.ctrip.framework.apollo.core.dto.ServiceDTO;
 import com.ctrip.framework.apollo.core.enums.Env;
 import com.ctrip.framework.apollo.core.utils.ClassLoaderUtil;
 import com.ctrip.framework.apollo.util.ConfigUtil;
-import com.google.common.collect.Lists;
 import com.google.gson.Gson;
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -67,25 +52,51 @@ public abstract class BaseIntegrationTest {
   protected static int refreshInterval;
   protected static TimeUnit refreshTimeUnit;
   protected static boolean propertiesOrderEnabled;
-  private Server server;
+  private MockedConfigService mockedConfigService;
   protected Gson gson = new Gson();
 
-  @Rule
-  public TestRule watcher = new TestWatcher() {
-    protected void starting(Description description) {
-      logger.info("Starting test: " + description.getMethodName());
-    }
+  protected MockedConfigService newMockedConfigService() {
+    this.mockedConfigService = new MockedConfigService(port);
+    this.mockedConfigService.init();
+    this.mockMetaServer();
+    return this.mockedConfigService;
+  }
 
-    protected void finished(Description description) {
-      logger.info("Finished test: " + description.getMethodName());
-    }
-  };
+  protected void mockMetaServer() {
+    mockMetaServer(false);
+  }
 
-  @Before
+  protected void mockMetaServer(boolean failedAtFirstTime) {
+    final ServiceDTO someServiceDTO = new ServiceDTO();
+    someServiceDTO.setAppName(someAppName);
+    someServiceDTO.setInstanceId(someInstanceId);
+    someServiceDTO.setHomepageUrl(configServiceURL);
+    this.mockedConfigService.mockMetaServer(failedAtFirstTime, someServiceDTO);
+  }
+
+  public void mockConfigs(
+      int mockedStatusCode,
+      ApolloConfig apolloConfig
+  ) {
+    this.mockConfigs(false, mockedStatusCode, apolloConfig);
+  }
+
+  public void mockConfigs(
+      boolean failedAtFirstTime,
+      int mockedStatusCode,
+      ApolloConfig apolloConfig
+  ) {
+    this.mockedConfigService.mockConfigs(
+        failedAtFirstTime, mockedStatusCode, apolloConfig
+    );
+  }
+
+  @BeforeEach
   public void setUp() throws Exception {
     someAppId = "1003171";
     someClusterName = "someClusterName";
     someDataCenter = "someDC";
+
     refreshInterval = 5;
     refreshTimeUnit = TimeUnit.MINUTES;
     propertiesOrderEnabled = false;
@@ -99,7 +110,7 @@ public abstract class BaseIntegrationTest {
     MockInjector.setInstance(ConfigUtil.class, new MockConfigUtil());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     //as ConfigService is singleton, so we must manually clear its container
     ConfigService.reset();
@@ -107,61 +118,10 @@ public abstract class BaseIntegrationTest {
     System.clearProperty(ConfigConsts.APOLLO_META_KEY);
     ReflectionTestUtils.invokeMethod(MetaDomainConsts.class, "reset");
 
-    if (server != null && server.isStarted()) {
-      server.stop();
+    if (mockedConfigService != null) {
+      mockedConfigService.close();
+      mockedConfigService = null;
     }
-  }
-
-  /**
-   * init and start a jetty server, remember to call server.stop when the task is finished
-   *
-   * @param handlers
-   * @throws Exception
-   */
-  protected Server startServerWithHandlers(ContextHandler... handlers) throws Exception {
-    server = new Server(port);
-
-    ContextHandlerCollection contexts = new ContextHandlerCollection();
-    contexts.setHandlers(handlers);
-    contexts.addHandler(mockMetaServerHandler());
-
-    server.setHandler(contexts);
-    server.start();
-
-    return server;
-  }
-
-  protected ContextHandler mockMetaServerHandler() {
-    return mockMetaServerHandler(false);
-  }
-
-  protected ContextHandler mockMetaServerHandler(final boolean failedAtFirstTime) {
-    final ServiceDTO someServiceDTO = new ServiceDTO();
-    someServiceDTO.setAppName(someAppName);
-    someServiceDTO.setInstanceId(someInstanceId);
-    someServiceDTO.setHomepageUrl(configServiceURL);
-    final AtomicInteger counter = new AtomicInteger(0);
-
-    ContextHandler context = new ContextHandler("/services/config");
-    context.setHandler(new AbstractHandler() {
-      @Override
-      public void handle(String target, Request baseRequest, HttpServletRequest request,
-          HttpServletResponse response) throws IOException, ServletException {
-        if (failedAtFirstTime && counter.incrementAndGet() == 1) {
-          response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-          baseRequest.setHandled(true);
-          return;
-        }
-        response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_OK);
-
-        response.getWriter().println(gson.toJson(Lists.newArrayList(someServiceDTO)));
-
-        baseRequest.setHandled(true);
-      }
-    });
-
-    return context;
   }
 
   protected void setRefreshInterval(int refreshInterval) {

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/MockedConfigService.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/MockedConfigService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package com.ctrip.framework.apollo;
 
 import com.ctrip.framework.apollo.core.dto.ApolloConfig;

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/MockedConfigService.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/MockedConfigService.java
@@ -1,0 +1,192 @@
+package com.ctrip.framework.apollo;
+
+import com.ctrip.framework.apollo.core.dto.ApolloConfig;
+import com.ctrip.framework.apollo.core.dto.ApolloConfigNotification;
+import com.ctrip.framework.apollo.core.dto.ServiceDTO;
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.servlet.http.HttpServletResponse;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.matchers.Times;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.MediaType;
+import org.mockserver.model.RequestDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author wxq
+ */
+public class MockedConfigService implements AutoCloseable {
+
+  private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+  private final Gson gson = new Gson();
+  private volatile ClientAndServer server;
+
+  private final int port;
+
+  public MockedConfigService(int port) {
+    log.info("custom MockedConfigService use port: {}", port);
+    this.port = port;
+  }
+
+  public static void main(String[] args) {
+    Runnable runnable = () -> {
+      MockedConfigService mockedConfigService = new MockedConfigService(10000);
+      mockedConfigService.init();
+      mockedConfigService.mockMetaServer(
+          true,
+          new ServiceDTO()
+      );
+      mockedConfigService.mockConfigs(
+          true,
+          200,
+          new ApolloConfig()
+      );
+      mockedConfigService.mockLongPollNotifications(
+          false,
+          1000, 200, Lists.newArrayList(new ApolloConfigNotification("someNamespace", 1))
+      );
+      mockedConfigService.mockConfigs(
+          false,
+          200,
+          new ApolloConfig()
+      );
+      mockedConfigService.mockConfigs(
+          false,
+          200,
+          null
+      );
+    };
+    Thread thread = new Thread(runnable);
+    thread.start();
+    System.out.println("wait");
+  }
+
+  public void init() {
+    this.server = ClientAndServer.startClientAndServer(port);
+  }
+
+  public void mockMetaServer(ServiceDTO ... serviceDTOList) {
+    mockMetaServer(false, serviceDTOList);
+  }
+
+  /**
+   * @param serviceDTOList apollo meta server's response
+   */
+  public void mockMetaServer(boolean failedAtFirstTime, ServiceDTO ... serviceDTOList) {
+    final String path = "/services/config";
+    RequestDefinition requestDefinition = HttpRequest.request("GET").withPath(path);
+
+    // need clear
+    server.clear(requestDefinition);
+
+    if (failedAtFirstTime) {
+      server.when(requestDefinition, Times.exactly(1))
+          .respond(HttpResponse.response()
+              .withStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+              .withContentType(MediaType.JSON_UTF_8)
+          );
+    }
+
+    String body = gson.toJson(Lists.newArrayList(serviceDTOList));
+    server.when(requestDefinition)
+        .respond(HttpResponse.response()
+            .withStatusCode(HttpServletResponse.SC_OK)
+            .withContentType(MediaType.JSON_UTF_8)
+            .withBody(body)
+        );
+  }
+
+  public void mockConfigs(
+      int mockedStatusCode,
+      ApolloConfig apolloConfig
+  ) {
+    mockConfigs(false, mockedStatusCode, apolloConfig);
+  }
+
+  /**
+   * @param failedAtFirstTime failed at first time
+   * @param mockedStatusCode http status code
+   * @param apolloConfig apollo config server's response
+   */
+  public void mockConfigs(
+      boolean failedAtFirstTime,
+      int mockedStatusCode,
+      ApolloConfig apolloConfig
+  ) {
+    // cannot use /configs/* as the path, because mock server will treat * as a wildcard
+    final String path = "/configs/.*";
+    RequestDefinition requestDefinition = HttpRequest.request("GET").withPath(path);
+
+    // need clear
+    server.clear(requestDefinition);
+
+    if (failedAtFirstTime) {
+      server.when(requestDefinition, Times.exactly(1))
+          .respond(HttpResponse.response()
+              .withStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+              .withContentType(MediaType.JSON_UTF_8)
+          );
+    }
+
+    String body = gson.toJson(apolloConfig);
+    server.when(requestDefinition)
+        .respond(HttpResponse.response()
+            .withStatusCode(mockedStatusCode)
+            .withContentType(MediaType.JSON_UTF_8)
+            .withBody(body)
+        );
+  }
+
+  public void mockLongPollNotifications(
+      final long pollResultTimeOutInMS,
+      final int statusCode,
+      final List<ApolloConfigNotification> result
+  ) {
+    mockLongPollNotifications(
+        false, pollResultTimeOutInMS, statusCode, result);
+  }
+
+  public void mockLongPollNotifications(
+      final boolean failedAtFirstTime,
+      final long pollResultTimeOutInMS,
+      final int statusCode,
+      final List<ApolloConfigNotification> result
+  ) {
+    // match all parameters
+    final String path = "/notifications/v2?.*";
+    RequestDefinition requestDefinition = HttpRequest.request("GET").withPath(path);
+
+    // need clear
+    server.clear(requestDefinition);
+
+    if (failedAtFirstTime) {
+      server.when(requestDefinition, Times.exactly(1))
+          .respond(HttpResponse.response()
+              .withStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+              .withContentType(MediaType.JSON_UTF_8)
+          );
+    }
+
+    String body = gson.toJson(result);
+    server.when(requestDefinition)
+        .respond(HttpResponse.response()
+            .withStatusCode(statusCode)
+            .withContentType(MediaType.JSON_UTF_8)
+            .withBody(body)
+            .withDelay(TimeUnit.MILLISECONDS, pollResultTimeOutInMS)
+        );
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (this.server.isRunning()) {
+      this.server.stop();
+    }
+  }
+}

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepositoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepositoryTest.java
@@ -186,6 +186,8 @@ public class LocalFileConfigRepositoryTest {
     LocalFileConfigRepository localFileConfigRepository =
         new LocalFileConfigRepository(someNamespace, upstreamRepo);
 
+    assertEquals(ConfigSourceType.LOCAL, localFileConfigRepository.getSourceType());
+    localFileConfigRepository.trySync();
     assertEquals(someSourceType, localFileConfigRepository.getSourceType());
 
     localFileConfigRepository.setLocalCacheDir(someBaseDir, true);

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepositoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepositoryTest.java
@@ -187,7 +187,7 @@ public class LocalFileConfigRepositoryTest {
         new LocalFileConfigRepository(someNamespace, upstreamRepo);
 
     assertEquals(ConfigSourceType.LOCAL, localFileConfigRepository.getSourceType());
-    localFileConfigRepository.trySync();
+    localFileConfigRepository.initialize();
     assertEquals(someSourceType, localFileConfigRepository.getSourceType());
 
     localFileConfigRepository.setLocalCacheDir(someBaseDir, true);

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
@@ -320,7 +320,7 @@ public class RemoteConfigRepositoryTest {
 
     final ArgumentCaptor<HttpRequest> httpRequestArgumentCaptor = ArgumentCaptor
         .forClass(HttpRequest.class);
-    verify(httpClient, atLeast(2)).doGet(httpRequestArgumentCaptor.capture(), eq(ApolloConfig.class));
+    verify(httpClient, atLeast(1)).doGet(httpRequestArgumentCaptor.capture(), eq(ApolloConfig.class));
 
     HttpRequest request = httpRequestArgumentCaptor.getValue();
 

--- a/apollo-client/src/test/resources/log4j2.xml
+++ b/apollo-client/src/test/resources/log4j2.xml
@@ -28,6 +28,8 @@
         <logger name="com.ctrip.framework.apollo" additivity="false" level="trace">
             <AppenderRef ref="Async" level="WARN"/>
         </logger>
+        <!-- MockServer change level="INFO" for http detail -->
+        <logger name="org.mockserver.log" level="WARN"/>
         <root level="INFO">
             <AppenderRef ref="Async"/>
         </root>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,13 @@
         <version>1.2.0</version>
         <scope>test</scope>
       </dependency>
+      <!-- mock server -->
+      <dependency>
+        <groupId>org.mock-server</groupId>
+        <artifactId>mockserver-netty</artifactId>
+        <version>5.15.0</version>
+        <scope>test</scope>
+      </dependency>
       <!-- declare Spring BOMs in order -->
       <dependency>
         <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## What's the purpose of this PR

Speed up the user's startup time,

by decrease the number of http requests.

## Which issue(s) this PR fixes:
Fixes https://github.com/apolloconfig/apollo-java/issues/60

## Brief changelog

before change, it use 11494 ms to load 10 namespace when meet 404, 
[before-change.log](https://github.com/apolloconfig/apollo-java/files/15237228/before-change.log)

after delete 2 http requests when context init, it use 1490 ms.
[after-change.log](https://github.com/apolloconfig/apollo-java/files/15237229/after-change.log)

i.e **from 11494 ms to 1490 ms**.

the code in 
https://github.com/apolloconfig/apollo-java/blob/bcc40531f32e74d0c639b5e5d2ab2995fd00c3d6/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java#L69
will ensure pull at least one time from remote when startup.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new initialization process in the configuration repository, enhancing the setup mechanism.

- **Bug Fixes**
  - Adjusted initialization calls to ensure proper configuration setup without redundant sync calls.

- **Tests**
  - Added assertions in tests to verify the source type before and after initialization, improving test coverage and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->