### PR TITLE
perf: speed up when startup meet timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Apollo Java 2.3.0
 * [Implement parsing time based on pattern for @ApolloJsonValue](https://github.com/apolloconfig/apollo-java/pull/53)
 * [Enhance to load mocked properties from apollo.cache-dir](https://github.com/apolloconfig/apollo-java/pull/58)
 * [perf: speed up the first loading of namespace when startup meet 404](https://github.com/apolloconfig/apollo-java/pull/61)
-* [perf: speed up when startup meet timeout](https://github.com/apolloconfig/apollo-java/pull/64)
+* [perf: speed up when startup meets timeout](https://github.com/apolloconfig/apollo-java/pull/64)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/3?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Apollo Java 2.3.0
 * [Implement parsing time based on pattern for @ApolloJsonValue](https://github.com/apolloconfig/apollo-java/pull/53)
 * [Enhance to load mocked properties from apollo.cache-dir](https://github.com/apolloconfig/apollo-java/pull/58)
 * [perf: speed up the first loading of namespace when startup meet 404](https://github.com/apolloconfig/apollo-java/pull/61)
+* [perf: speed up when startup meet timeout](https://github.com/apolloconfig/apollo-java/pull/64)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/3?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java
@@ -22,7 +22,6 @@ import com.ctrip.framework.apollo.core.utils.DeferredLoggerFactory;
 import com.ctrip.framework.apollo.core.utils.DeprecatedPropertyNotifyUtil;
 import com.ctrip.framework.foundation.Foundation;
 import java.lang.reflect.Type;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -30,6 +29,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.ctrip.framework.apollo.build.ApolloInjector;
 import com.ctrip.framework.apollo.core.dto.ServiceDTO;
@@ -54,11 +54,9 @@ public class ConfigServiceLocator {
   private static final Logger logger = DeferredLoggerFactory.getLogger(ConfigServiceLocator.class);
   private HttpClient m_httpClient;
   private ConfigUtil m_configUtil;
-  private final AtomicReference<List<ServiceDTO>> m_configServices = new AtomicReference<>(
-      Collections.emptyList());
-  private static final Type m_responseType = new TypeToken<List<ServiceDTO>>() {
-  }.getType();
-  ScheduledExecutorService m_executorService;
+  private AtomicReference<List<ServiceDTO>> m_configServices;
+  private Type m_responseType;
+  private ScheduledExecutorService m_executorService;
   private static final Joiner.MapJoiner MAP_JOINER = Joiner.on("&").withKeyValueSeparator("=");
   private static final Escaper queryParamEscaper = UrlEscapers.urlFormParameterEscaper();
 
@@ -66,21 +64,15 @@ public class ConfigServiceLocator {
    * Create a config service locator.
    */
   public ConfigServiceLocator() {
-  }
-
-  /**
-   * only init once.
-   */
-  private void initialize() {
-    if (m_httpClient == null) {
-      synchronized (this) {
-        if (m_httpClient == null) {
-          m_httpClient = ApolloInjector.getInstance(HttpClient.class);
-          m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
-          initConfigServices();
-        }
-      }
-    }
+    List<ServiceDTO> initial = Lists.newArrayList();
+    m_configServices = new AtomicReference<>(initial);
+    m_responseType = new TypeToken<List<ServiceDTO>>() {
+    }.getType();
+    m_httpClient = ApolloInjector.getInstance(HttpClient.class);
+    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    this.m_executorService = Executors.newScheduledThreadPool(1,
+        ApolloThreadFactory.create("ConfigServiceLocator", true));
+    initConfigServices();
   }
 
   private void initConfigServices() {
@@ -168,14 +160,8 @@ public class ConfigServiceLocator {
    * @return the services dto
    */
   public List<ServiceDTO> getConfigServices() {
-    initialize();
     if (m_configServices.get().isEmpty()) {
-      // quick fail
-      throw new ApolloConfigException(
-          "No available config service, "
-              + "server side maybe crash or network cannot connect to server from this ip, "
-          + "one of meta service url is " + assembleMetaServiceUrl()
-      );
+      updateConfigServices();
     }
 
     return m_configServices.get();
@@ -192,8 +178,6 @@ public class ConfigServiceLocator {
   }
 
   private void schedulePeriodicRefresh() {
-    this.m_executorService = Executors.newScheduledThreadPool(1,
-        ApolloThreadFactory.create("ConfigServiceLocator", true));
     this.m_executorService.scheduleAtFixedRate(
         new Runnable() {
           @Override
@@ -206,7 +190,7 @@ public class ConfigServiceLocator {
         m_configUtil.getRefreshIntervalTimeUnit());
   }
 
-  synchronized void updateConfigServices() {
+  private synchronized void updateConfigServices() {
     String url = assembleMetaServiceUrl();
 
     HttpRequest request = new HttpRequest(url);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java
@@ -161,7 +161,13 @@ public class ConfigServiceLocator {
    */
   public List<ServiceDTO> getConfigServices() {
     if (m_configServices.get().isEmpty()) {
-      updateConfigServices();
+      m_executorService.submit(() -> this.tryUpdateConfigServices());
+      // quick fail
+      throw new ApolloConfigException(
+          "No available config service, "
+              + "server side maybe crash or network cannot connect to server from this ip, "
+              + "one of meta service url is " + assembleMetaServiceUrl()
+      );
     }
 
     return m_configServices.get();

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java
@@ -200,6 +200,11 @@ public class ConfigServiceLocator {
     String url = assembleMetaServiceUrl();
 
     HttpRequest request = new HttpRequest(url);
+    // speed up http request
+    int mixTimeout = Math.min(m_configUtil.getConnectTimeout(), m_configUtil.getReadTimeout());
+    request.setConnectTimeout(mixTimeout);
+    request.setReadTimeout(mixTimeout);
+
     int maxRetries = 2;
     Throwable exception = null;
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ConfigUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ConfigUtil.java
@@ -38,6 +38,18 @@ import org.slf4j.LoggerFactory;
 public class ConfigUtil {
 
   private static final Logger logger = LoggerFactory.getLogger(ConfigUtil.class);
+
+  /**
+   * qps limit: discovery config service from meta
+   * <p>
+   * 1 times per second
+   */
+  private int discoveryQPS = 1;
+  /** 1 second */
+  private int discoveryConnectTimeout = 1000;
+  /** 1 second */
+  private int discoveryReadTimeout = 1000;
+
   private int refreshInterval = 5;
   private TimeUnit refreshIntervalTimeUnit = TimeUnit.MINUTES;
   private int connectTimeout = 1000; //1 second
@@ -210,24 +222,63 @@ public class ConfigUtil {
     return refreshIntervalTimeUnit;
   }
 
-  private void initQPS() {
-    String customizedLoadConfigQPS = System.getProperty("apollo.loadConfigQPS");
-    if (!Strings.isNullOrEmpty(customizedLoadConfigQPS)) {
+  static Integer getCustomizedIntegerValue(String systemKey) {
+    String customizedValue = System.getProperty(systemKey);
+    if (!Strings.isNullOrEmpty(customizedValue)) {
       try {
-        loadConfigQPS = Integer.parseInt(customizedLoadConfigQPS);
+        return Integer.parseInt(customizedValue);
       } catch (Throwable ex) {
-        logger.error("Config for apollo.loadConfigQPS is invalid: {}", customizedLoadConfigQPS);
+        logger.error("Config for {} is invalid: {}", systemKey, customizedValue);
+      }
+    }
+    return null;
+  }
+
+  private void initQPS() {
+    {
+      Integer value = getCustomizedIntegerValue("apollo.discoveryConnectTimeout");
+      if (null != value) {
+        discoveryConnectTimeout = value;
+      }
+    }
+    {
+      Integer value = getCustomizedIntegerValue("apollo.discoveryReadTimeout");
+      if (null != value) {
+        discoveryReadTimeout = value;
+      }
+    }
+    {
+      Integer value = getCustomizedIntegerValue("apollo.discoveryQPS");
+      if (null != value) {
+        discoveryQPS = value;
       }
     }
 
-    String customizedLongPollQPS = System.getProperty("apollo.longPollQPS");
-    if (!Strings.isNullOrEmpty(customizedLongPollQPS)) {
-      try {
-        longPollQPS = Integer.parseInt(customizedLongPollQPS);
-      } catch (Throwable ex) {
-        logger.error("Config for apollo.longPollQPS is invalid: {}", customizedLongPollQPS);
+    {
+      Integer value = getCustomizedIntegerValue("apollo.loadConfigQPS");
+      if (null != value) {
+        loadConfigQPS = value;
       }
     }
+
+    {
+      Integer value = getCustomizedIntegerValue("apollo.longPollQPS");
+      if (null != value) {
+        longPollQPS = value;
+      }
+    }
+  }
+
+  public int getDiscoveryQPS() {
+    return discoveryQPS;
+  }
+
+  public int getDiscoveryConnectTimeout() {
+    return discoveryConnectTimeout;
+  }
+
+  public int getDiscoveryReadTimeout() {
+    return discoveryReadTimeout;
   }
 
   public int getLoadConfigQPS() {

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/BaseIntegrationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/BaseIntegrationTest.java
@@ -62,7 +62,6 @@ public abstract class BaseIntegrationTest {
   protected static TimeUnit refreshTimeUnit;
   protected static boolean propertiesOrderEnabled;
   private MockedConfigService mockedConfigService;
-  protected Gson gson = new Gson();
 
   protected final String defaultNamespace = ConfigConsts.NAMESPACE_APPLICATION;
 
@@ -135,6 +134,9 @@ public abstract class BaseIntegrationTest {
 
   @AfterEach
   public void tearDown() throws Exception {
+    ReflectionTestUtils.invokeMethod(remoteConfigLongPollService, "stopLongPollingRefresh");
+    recursiveDelete(configDir);
+
     //as ConfigService is singleton, so we must manually clear its container
     ConfigService.reset();
     MockInjector.reset();
@@ -145,9 +147,6 @@ public abstract class BaseIntegrationTest {
       mockedConfigService.close();
       mockedConfigService = null;
     }
-
-    recursiveDelete(configDir);
-    ReflectionTestUtils.invokeMethod(remoteConfigLongPollService, "stopLongPollingRefresh");
   }
 
   private void recursiveDelete(File file) {

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/BaseIntegrationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/BaseIntegrationTest.java
@@ -24,7 +24,6 @@ import com.ctrip.framework.apollo.core.dto.ServiceDTO;
 import com.ctrip.framework.apollo.internals.RemoteConfigLongPollService;
 import com.google.common.base.Joiner;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -66,8 +65,6 @@ public abstract class BaseIntegrationTest {
   protected final String defaultNamespace = ConfigConsts.NAMESPACE_APPLICATION;
 
   private File configDir;
-
-  private RemoteConfigLongPollService remoteConfigLongPollService;
 
 
   protected MockedConfigService newMockedConfigService() {
@@ -129,11 +126,13 @@ public abstract class BaseIntegrationTest {
       configDir.delete();
     }
     configDir.mkdirs();
-    remoteConfigLongPollService = ApolloInjector.getInstance(RemoteConfigLongPollService.class);
   }
 
   @AfterEach
   public void tearDown() throws Exception {
+    // get the instance will trigger long poll task execute, so move it from setup to tearDown
+    RemoteConfigLongPollService remoteConfigLongPollService
+        = ApolloInjector.getInstance(RemoteConfigLongPollService.class);
     ReflectionTestUtils.invokeMethod(remoteConfigLongPollService, "stopLongPollingRefresh");
     recursiveDelete(configDir);
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/MockedConfigService.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/MockedConfigService.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletResponse;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.Times;
-import org.mockserver.model.HttpClassCallback;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.MediaType;
@@ -39,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MockedConfigService implements AutoCloseable {
 
-  private static final String META_SERVER_PATH = "/services/config";
+  private static final String META_SERVER_PATH = "/services/config?.*";
 
   private final Logger log = LoggerFactory.getLogger(this.getClass());
 
@@ -98,8 +97,8 @@ public class MockedConfigService implements AutoCloseable {
    * @param serviceDTOList apollo meta server's response
    */
   public void mockMetaServer(boolean failedAtFirstTime, ServiceDTO ... serviceDTOList) {
-    final String path = META_SERVER_PATH;
-    RequestDefinition requestDefinition = HttpRequest.request("GET").withPath(path);
+    RequestDefinition requestDefinition = HttpRequest.request("GET")
+        .withPath(META_SERVER_PATH);
 
     // need clear
     server.clear(requestDefinition);
@@ -125,8 +124,8 @@ public class MockedConfigService implements AutoCloseable {
    * simulate timeout
    */
   public void mockMetaSeverWithDelay(long milliseconds, ServiceDTO ... serviceDTOList) {
-    final String path = META_SERVER_PATH;
-    RequestDefinition requestDefinition = HttpRequest.request("GET").withPath(path);
+    RequestDefinition requestDefinition = HttpRequest.request("GET")
+        .withPath(META_SERVER_PATH);
 
     // need clear
     server.clear(requestDefinition);

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/MockedConfigService.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/MockedConfigService.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletResponse;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.Times;
+import org.mockserver.model.HttpClassCallback;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.MediaType;
@@ -37,6 +38,8 @@ import org.slf4j.LoggerFactory;
  * @author wxq
  */
 public class MockedConfigService implements AutoCloseable {
+
+  private static final String META_SERVER_PATH = "/services/config";
 
   private final Logger log = LoggerFactory.getLogger(this.getClass());
 
@@ -95,7 +98,7 @@ public class MockedConfigService implements AutoCloseable {
    * @param serviceDTOList apollo meta server's response
    */
   public void mockMetaServer(boolean failedAtFirstTime, ServiceDTO ... serviceDTOList) {
-    final String path = "/services/config";
+    final String path = META_SERVER_PATH;
     RequestDefinition requestDefinition = HttpRequest.request("GET").withPath(path);
 
     // need clear
@@ -112,6 +115,26 @@ public class MockedConfigService implements AutoCloseable {
     String body = gson.toJson(Lists.newArrayList(serviceDTOList));
     server.when(requestDefinition)
         .respond(HttpResponse.response()
+            .withStatusCode(HttpServletResponse.SC_OK)
+            .withContentType(MediaType.JSON_UTF_8)
+            .withBody(body)
+        );
+  }
+
+  /**
+   * simulate timeout
+   */
+  public void mockMetaSeverWithDelay(long milliseconds, ServiceDTO ... serviceDTOList) {
+    final String path = META_SERVER_PATH;
+    RequestDefinition requestDefinition = HttpRequest.request("GET").withPath(path);
+
+    // need clear
+    server.clear(requestDefinition);
+
+    String body = gson.toJson(Lists.newArrayList(serviceDTOList));
+    server.when(requestDefinition)
+        .respond(HttpResponse.response()
+            .withDelay(TimeUnit.MILLISECONDS, milliseconds)
             .withStatusCode(HttpServletResponse.SC_OK)
             .withContentType(MediaType.JSON_UTF_8)
             .withBody(body)

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/integration/ConfigIntegrationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/integration/ConfigIntegrationTest.java
@@ -57,7 +57,7 @@ public class ConfigIntegrationTest extends BaseIntegrationTest {
     String someNonExistedKey = "someNonExistedKey";
     String someDefaultValue = "someDefaultValue";
     ApolloConfig apolloConfig = assembleApolloConfig(ImmutableMap.of(someKey, someValue));
-    MockedConfigService mockedConfigService = newMockedConfigService();
+    newMockedConfigService();
     mockConfigs(HttpServletResponse.SC_OK, apolloConfig);
 
     Config config = ConfigService.getAppConfig();
@@ -78,7 +78,7 @@ public class ConfigIntegrationTest extends BaseIntegrationTest {
     configurations.put(someKey1, someValue1);
     configurations.put(someKey2, someValue2);
     ApolloConfig apolloConfig = assembleApolloConfig(ImmutableMap.copyOf(configurations));
-    MockedConfigService mockedConfigService = newMockedConfigService();
+    newMockedConfigService();
     mockConfigs(HttpServletResponse.SC_OK, apolloConfig);
 
     Config config = ConfigService.getAppConfig();
@@ -100,7 +100,7 @@ public class ConfigIntegrationTest extends BaseIntegrationTest {
     createLocalCachePropertyFile(properties);
 
     ApolloConfig apolloConfig = assembleApolloConfig(ImmutableMap.of(someKey, anotherValue));
-    MockedConfigService mockedConfigService = newMockedConfigService();
+    newMockedConfigService();
     mockConfigs(HttpServletResponse.SC_OK, apolloConfig);
 
     Config config = ConfigService.getAppConfig();

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/integration/ConfigServiceTimeoutIntegrationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/integration/ConfigServiceTimeoutIntegrationTest.java
@@ -1,0 +1,256 @@
+package com.ctrip.framework.apollo.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.ctrip.framework.apollo.BaseIntegrationTest;
+import com.ctrip.framework.apollo.Config;
+import com.ctrip.framework.apollo.ConfigChangeListener;
+import com.ctrip.framework.apollo.ConfigService;
+import com.ctrip.framework.apollo.MockedConfigService;
+import com.ctrip.framework.apollo.core.dto.ApolloConfig;
+import com.ctrip.framework.apollo.core.dto.ApolloConfigNotification;
+import com.ctrip.framework.apollo.model.ConfigChangeEvent;
+import com.ctrip.framework.apollo.util.OrderedProperties;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.SettableFuture;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+
+class ConfigServiceTimeoutIntegrationTest extends BaseIntegrationTest {
+
+  @Test
+  void timeoutWhenGet10Namespace() throws ExecutionException, InterruptedException, TimeoutException {
+    MockedConfigService  mockedConfigService = newMockedConfigService();
+    mockedConfigService.mockMetaSeverWithDelay(30_000);
+
+    final SettableFuture<Boolean> loadFinished = SettableFuture.create();
+
+    final int namespaceCount = 10;
+    List<Config> configList = new ArrayList<>(namespaceCount);
+    Runnable runnable = () -> {
+      // try to get multiple namespace
+      for (int i = 0; i < namespaceCount; i++) {
+        String ns = "ns" + i;
+        Config config = ConfigService.getConfig(ns);
+        configList.add(config);
+      }
+      loadFinished.set(true);
+    };
+    Thread thread = new Thread(runnable);
+    thread.start();
+
+    loadFinished.get(10_000, TimeUnit.MILLISECONDS);
+    assertEquals(namespaceCount, configList.size());
+  }
+
+  @Test
+  void giveDefaultNamespaceConfigBackupWhenMeetTimeout()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    Properties properties = new OrderedProperties();
+    properties.put("k1", "v1");
+    properties.put("k2", "v2");
+    properties.put("k3", "v3");
+    createLocalCachePropertyFile(properties);
+
+    MockedConfigService  mockedConfigService = newMockedConfigService();
+    mockedConfigService.mockMetaSeverWithDelay(30_000);
+
+    final SettableFuture<Config> configSettableFuture = SettableFuture.create();
+    Runnable runnable = () -> {
+      Config config = ConfigService.getAppConfig();
+      configSettableFuture.set(config);
+    };
+    Thread thread = new Thread(runnable);
+    thread.start();
+
+    Config config = configSettableFuture.get(10_000, TimeUnit.MILLISECONDS);
+    assertEquals("v1", config.getProperty("k1", null));
+    assertEquals("v2", config.getProperty("k2", null));
+    assertEquals("v3", config.getProperty("k3", null));
+  }
+
+  @Test
+  void give9NamespaceConfigBackupWhenMeetTimeout()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    final int numberOfNamespace = 10;
+    final String nsPrefix = "backupNs";
+    List<String> nsList = new ArrayList<>(numberOfNamespace);
+    List<SettableFuture<Config>> futureList = new ArrayList<>(numberOfNamespace);
+
+    // init
+    for (int i = 0; i < numberOfNamespace; i++) {
+      final String ns = nsPrefix + i;
+      nsList.add(ns);
+      futureList.add(SettableFuture.create());
+    }
+
+    // create backup for 9 namespace
+    // there is no backup for last namespace
+    for (int i = 0; i < numberOfNamespace - 1; i++) {
+      final String ns = nsPrefix + i;
+      // create backup in local
+      Properties properties = new OrderedProperties();
+      properties.put(ns + ".k1", ns + ".v1");
+      properties.put(ns + ".k2", ns + ".v2");
+      properties.put(ns + ".k3", ns + ".v3");
+      createLocalCachePropertyFile(ns, properties);
+    }
+
+    MockedConfigService  mockedConfigService = newMockedConfigService();
+    mockedConfigService.mockMetaSeverWithDelay(30_000);
+
+    // concurrent execute
+    for (int i = 0; i < numberOfNamespace; i++) {
+      final String ns = nsList.get(i);
+      final int index = i;
+      Runnable runnable = () -> {
+          Config config = ConfigService.getConfig(ns);
+          futureList.get(index).set(config);
+      };
+      Thread thread = new Thread(runnable);
+      thread.start();
+    }
+
+    // wait last namespace
+    {
+      SettableFuture<Config> future = futureList.get(numberOfNamespace - 1);
+      Config config = future.get(10_000, TimeUnit.MILLISECONDS);
+      // no item here because there is no backup for this namespace
+      assertTrue(config.getPropertyNames().isEmpty());
+    }
+
+    // check 9 namespace
+    for (int i = 0; i < numberOfNamespace - 1; i++) {
+      String ns = nsList.get(i);
+      SettableFuture<Config> future = futureList.get(i);
+      Config config = future.get(10_000, TimeUnit.MILLISECONDS);
+      assertEquals(ns + ".v1", config.getProperty(ns + ".k1", null));
+      assertEquals(ns + ".v2", config.getProperty(ns + ".k2", null));
+      assertEquals(ns + ".v3", config.getProperty(ns + ".k3", null));
+    }
+
+  }
+
+  @Test
+  void giveTimeoutThenRecover() throws ExecutionException, InterruptedException, TimeoutException {
+    final String ns = "recoverNsXxx";
+    final String k1 = "k1";
+    final String k2 = "k2";
+    final String k3 = "k3";
+
+    final String v1 = "v1";
+    final String v2 = "v2";
+    final String v3 = "v3";
+
+    // create backup first
+    {
+      Properties properties = new OrderedProperties();
+      properties.put(k1, v1);
+      properties.put(k2, v2);
+      properties.put(k3, v3);
+      createLocalCachePropertyFile(ns, properties);
+    }
+
+    MockedConfigService  mockedConfigService = newMockedConfigService();
+
+    // simulate timeout, so will read local backup
+    mockedConfigService.mockMetaSeverWithDelay(30_000);
+    {
+      final SettableFuture<Config> configSettableFuture = SettableFuture.create();
+      Runnable runnable = () -> {
+        Config config = ConfigService.getConfig(ns);
+        configSettableFuture.set(config);
+      };
+      Thread thread = new Thread(runnable);
+      thread.start();
+
+      Config config = configSettableFuture.get(10_000, TimeUnit.MILLISECONDS);
+      log.info("get namespace '{}' from backup success", ns);
+      assertEquals(v1, config.getProperty(k1, null));
+      assertEquals(v2, config.getProperty(k2, null));
+      assertEquals(v3, config.getProperty(k3, null));
+    }
+
+    final BlockingQueue<ConfigChangeEvent> longPollFinishedSignal = new ArrayBlockingQueue<>(1);
+    // add listener first
+    final Config config = ConfigService.getConfig(ns);
+    config.addChangeListener(new ConfigChangeListener() {
+      @Override
+      public void onChange(ConfigChangeEvent changeEvent) {
+        longPollFinishedSignal.add(changeEvent);
+      }
+    });
+
+    // recover and change the config
+    final String recoverValue = "recoverValue";
+    final long recoverNotificationId = 1;
+    final long pollTimeoutInMS = 50;
+
+    // change the config and notify
+    {
+      Map<String, String> configurations = Maps.newHashMap();
+      configurations.put(k1, recoverValue);
+      ApolloConfig apolloConfig = assembleApolloConfig(ns, "releaseKey1", configurations);
+      // change the config
+      mockConfigs(HttpServletResponse.SC_OK, apolloConfig);
+      // notify
+      mockedConfigService.mockLongPollNotifications(
+          pollTimeoutInMS, HttpServletResponse.SC_OK,
+          Lists.newArrayList(
+              new ApolloConfigNotification(apolloConfig.getNamespaceName(), recoverNotificationId))
+      );
+    }
+
+    // recover meta service
+    log.info("recover meta service");
+    mockMetaServer();
+
+    // wait
+    {
+      ConfigChangeEvent event = longPollFinishedSignal.poll(10_000, TimeUnit.MILLISECONDS);
+      assertNotNull(event, "namespace '" + ns + "' should receive notify");
+    }
+
+    // check config
+    assertEquals(recoverValue, config.getProperty(k1, null));
+    assertNull(config.getProperty(k2, null));
+    assertNull(config.getProperty(k3, null));
+
+    log.info("change the config and notify again");
+    final String anotherRecoverValue = "anotherRecoverValue";
+    final long anotherRecoverNotificationId = 2;
+    {
+      Map<String, String> configurations = Maps.newHashMap();
+      configurations.put(k1, anotherRecoverValue);
+      ApolloConfig apolloConfig = assembleApolloConfig(ns, "releaseKey2", configurations);
+      // change the config
+      mockConfigs(HttpServletResponse.SC_OK, apolloConfig);
+      // notify
+      mockedConfigService.mockLongPollNotifications(
+          pollTimeoutInMS, HttpServletResponse.SC_OK,
+          Lists.newArrayList(
+              new ApolloConfigNotification(apolloConfig.getNamespaceName(), anotherRecoverNotificationId))
+      );
+    }
+
+    // wait
+    longPollFinishedSignal.poll(5000, TimeUnit.MILLISECONDS);
+    // check config
+    assertEquals(anotherRecoverValue, config.getProperty(k1, null));
+    assertNull(config.getProperty(k2, null));
+    assertNull(config.getProperty(k3, null));
+  }
+}

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/integration/ConfigServiceTimeoutIntegrationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/integration/ConfigServiceTimeoutIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package com.ctrip.framework.apollo.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/ConfigServiceLocatorTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/ConfigServiceLocatorTest.java
@@ -51,8 +51,6 @@ public class ConfigServiceLocatorTest {
 
     assertEquals(someConfigServiceUrl.trim(), result.get(0).getHomepageUrl());
     assertEquals(anotherConfigServiceUrl.trim(), result.get(1).getHomepageUrl());
-
-    assertNull(configServiceLocator.m_executorService, "thread pool should be null");
   }
 
   @Test
@@ -71,8 +69,6 @@ public class ConfigServiceLocatorTest {
 
     assertEquals(someConfigServiceUrl.trim(), result.get(0).getHomepageUrl());
     assertEquals(anotherConfigServiceUrl.trim(), result.get(1).getHomepageUrl());
-
-    assertNull(configServiceLocator.m_executorService, "thread pool should be null");
   }
 
   @Test

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/ConfigServiceLocatorTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/ConfigServiceLocatorTest.java
@@ -16,17 +16,21 @@
  */
 package com.ctrip.framework.apollo.internals;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.ctrip.framework.apollo.core.ApolloClientSystemConsts;
 import com.ctrip.framework.apollo.core.dto.ServiceDTO;
+import com.ctrip.framework.apollo.exceptions.ApolloConfigException;
 import java.util.List;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class ConfigServiceLocatorTest {
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     System.clearProperty(ApolloClientSystemConsts.APOLLO_CONFIG_SERVICE);
     System.clearProperty(ApolloClientSystemConsts.DEPRECATED_APOLLO_CONFIG_SERVICE);
@@ -47,6 +51,8 @@ public class ConfigServiceLocatorTest {
 
     assertEquals(someConfigServiceUrl.trim(), result.get(0).getHomepageUrl());
     assertEquals(anotherConfigServiceUrl.trim(), result.get(1).getHomepageUrl());
+
+    assertNull(configServiceLocator.m_executorService, "thread pool should be null");
   }
 
   @Test
@@ -65,5 +71,19 @@ public class ConfigServiceLocatorTest {
 
     assertEquals(someConfigServiceUrl.trim(), result.get(0).getHomepageUrl());
     assertEquals(anotherConfigServiceUrl.trim(), result.get(1).getHomepageUrl());
+
+    assertNull(configServiceLocator.m_executorService, "thread pool should be null");
+  }
+
+  @Test
+  public void giveNoUsableConfigServiceThenThrowExceptionQuickly() {
+    ConfigServiceLocator configServiceLocator = Mockito.spy(
+        new ConfigServiceLocator()
+    );
+    // speed up test case
+    Mockito.doNothing().when(configServiceLocator).updateConfigServices();
+    assertThrows(ApolloConfigException.class, () -> {
+      configServiceLocator.getConfigServices();
+    });
   }
 }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/ConfigServiceLocatorTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/ConfigServiceLocatorTest.java
@@ -76,8 +76,6 @@ public class ConfigServiceLocatorTest {
     ConfigServiceLocator configServiceLocator = Mockito.spy(
         new ConfigServiceLocator()
     );
-    // speed up test case
-    Mockito.doNothing().when(configServiceLocator).updateConfigServices();
     assertThrows(ApolloConfigException.class, () -> {
       configServiceLocator.getConfigServices();
     });

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
@@ -131,6 +131,7 @@ public class RemoteConfigRepositoryTest {
   @After
   public void tearDown() throws Exception {
     MockInjector.reset();
+    remoteConfigLongPollService.stopLongPollingRefresh();
   }
 
   @Test
@@ -150,7 +151,6 @@ public class RemoteConfigRepositoryTest {
 
     assertEquals(configurations, config);
     assertEquals(ConfigSourceType.REMOTE, remoteConfigRepository.getSourceType());
-    remoteConfigLongPollService.stopLongPollingRefresh();
   }
 
   @Test
@@ -178,7 +178,6 @@ public class RemoteConfigRepositoryTest {
     assertTrue(config instanceof OrderedProperties);
     assertEquals(configurations, config);
     assertEquals(ConfigSourceType.REMOTE, remoteConfigRepository.getSourceType());
-    remoteConfigLongPollService.stopLongPollingRefresh();
 
     String[] actualArrays = config.keySet().toArray(new String[]{});
     String[] expectedArrays = {"someKey", "someKey2"};
@@ -215,7 +214,6 @@ public class RemoteConfigRepositoryTest {
 
     assertEquals(configurations, config);
     assertEquals(ConfigSourceType.REMOTE, remoteConfigRepository.getSourceType());
-    remoteConfigLongPollService.stopLongPollingRefresh();
   }
 
   @Test(expected = ApolloConfigException.class)
@@ -267,8 +265,6 @@ public class RemoteConfigRepositoryTest {
     verify(someListener, times(1)).onRepositoryChange(eq(someNamespace), captor.capture());
 
     assertEquals(newConfigurations, captor.getValue());
-
-    remoteConfigLongPollService.stopLongPollingRefresh();
   }
 
   @Test
@@ -352,7 +348,6 @@ public class RemoteConfigRepositoryTest {
             notificationMessages,
             someApolloConfig);
 
-    remoteConfigLongPollService.stopLongPollingRefresh();
     assertTrue(queryConfigUrl
         .contains(
             "http://someServer/configs/someAppId/someCluster+%20&.-_someSign/" + someNamespace));


### PR DESCRIPTION
## What's the purpose of this PR

Speed up when startup meet timeout, i.e when meet meta service and config service crash.

## Which issue(s) this PR fixes:
Fixes #60 

## Brief changelog

There is a synchronized lock in 

https://github.com/apolloconfig/apollo-java/blob/3f0979da3ea6478304719a71d4991fe4787558d1/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java#L193

It will block even use multiple thread.

When try to getConfigServices, if cache is empty, method `updateConfigServices` will be invoke

https://github.com/apolloconfig/apollo-java/blob/3f0979da3ea6478304719a71d4991fe4787558d1/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java#L162-L167

In this pr, the code change to **fail quickly**, so it can speed up when meta service and config service crash(that will cause timeout for client).

Maybe it better to let daemon thread to invoke method `updateConfigServices`, 
another thread just use the result in memory cache,
If there is no available config service, throw exception quickly.

After change, load 10 namespaces timeusage 
from **65929 ms to 5150ms** when all of them meet timeout


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced startup performance to handle timeout situations more efficiently in Apollo Java 2.3.0.

- **Bug Fixes**
  - Improved handling of configuration services with rate limiting and timeout settings.

- **Tests**
  - Added new test methods and assertions to ensure robust error handling and configuration updates.

- **Documentation**
  - Updated CHANGES.md to reflect performance enhancements in the Apollo Java 2.3.0 release.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->