### PR TITLE
fix the npe issue when @ApolloJsonValue is annotated on methods

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoUpdateConfigChangeListener.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoUpdateConfigChangeListener.java
@@ -113,7 +113,9 @@ public class AutoUpdateConfigChangeListener implements ConfigChangeListener,
         .resolvePropertyValue(beanFactory, springValue.getBeanName(), springValue.getPlaceholder());
 
     if (springValue.isJson()) {
-      ApolloJsonValue apolloJsonValue = springValue.getField().getAnnotation(ApolloJsonValue.class);
+      ApolloJsonValue apolloJsonValue = springValue.isField() ?
+              springValue.getField().getAnnotation(ApolloJsonValue.class) :
+              springValue.getMethodParameter().getMethodAnnotation(ApolloJsonValue.class);
       String datePattern = apolloJsonValue != null ? apolloJsonValue.datePattern() : StringUtils.EMPTY;
       value = parseJsonValue((String) value, springValue.getGenericType(), datePattern);
     } else {


### PR DESCRIPTION
## What's the purpose of this PR

#53 introduced a feature that parses time based on a pattern for `@ApolloJsonValue`. However, it caused an issue with NullPointerException (NPE) when `@ApolloJsonValue` is used as a method annotation. This pull request aims to resolve that issue.

## Which issue(s) this PR fixes:
Fixes #53

## Brief changelog

* Fetch the annotation from method parameters when `@ApolloJsonValue` is applied to methods.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the `resolvePropertyValue` method to enhance the accuracy of JSON value handling by checking if `springValue` is a field or a method parameter before retrieving the `ApolloJsonValue` annotation. This ensures correct `datePattern` retrieval for JSON values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->