### PR TITLE
feat: add configuration properties refresh

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloConfigurationPropertiesRefresh.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloConfigurationPropertiesRefresh.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.spring.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Use this annotation and <code>@ConfiguringProperties<code> to refresh `ConfigurationProperties`.
+ *
+ * <p>Usage example:</p>
+ * <pre class="code">
+ * &#064;Component
+ * &#064;ConfigurationProperties(prefix = "redis.cache")
+ * &#064;ApolloConfigurationPropertiesRefresh
+ * public class SampleRedisConfig implements InitializingBean {
+ *   private int expireSeconds;
+ *   private String clusterNodes;
+ *   private int commandTimeout;
+ *   private Map<String, String> someMap = Maps.newLinkedHashMap();
+ *   private List<String> someList = Lists.newLinkedList();
+ *   public void setExpireSeconds(int expireSeconds) {
+ *     this.expireSeconds = expireSeconds;
+ *   }
+ *   public void setClusterNodes(String clusterNodes) {
+ *     this.clusterNodes = clusterNodes;
+ *   }
+ *   public void setCommandTimeout(int commandTimeout) {
+ *     this.commandTimeout = commandTimeout;
+ *   }
+ *   public Map<String, String> getSomeMap() {
+ *     return someMap;
+ *   }
+ *   public List<String> getSomeList() {
+ *     return someList;
+ *   }
+ * }
+ * </pre>
+ *
+ *
+ * You may set up data like the following in Apollo: <br /><br /> Properties Sample:
+ * application.properties
+ * <pre>
+ * redis.cache.expireSeconds = 100
+ * redis.cache.clusterNodes = 1,2
+ * redis.cache.commandTimeout = 50
+ * redis.cache.someMap.key1 = a
+ * redis.cache.someMap.key2 = b
+ * redis.cache.someList[0] = c
+ * redis.cache.someList[1] = d
+ * </pre>
+ *
+ * Yaml Sample: application.yaml
+ * <pre>
+ * redis:
+ *   cache:
+ *     expireSeconds: 100
+ *     clusterNodes: 1,2
+ *     commandTimeout: 50
+ *     someMap:
+ *       key1: a
+ *       key2: b
+ *     someList:
+ *     - c
+ *     - d
+ * </pre>
+ *
+ * Ensure <code>apollo.autoRefreshConfigurationProperties</code> should be true.<br />
+ * In Spring Cloud environment, <code>@RefreshScope<code> can replace this annotation to refresh `ConfigurationProperties`.
+ *
+ * @author licheng
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+public @interface ApolloConfigurationPropertiesRefresh {
+
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloConfigurationPropertiesRefresh.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/ApolloConfigurationPropertiesRefresh.java
@@ -19,7 +19,7 @@ package com.ctrip.framework.apollo.spring.annotation;
 import java.lang.annotation.*;
 
 /**
- * Use this annotation and <code>@ConfiguringProperties<code> to refresh `ConfigurationProperties`.
+ * Use this annotation and <code>@ConfiguringProperties<code> to refresh ConfigurationProperties.
  *
  * <p>Usage example:</p>
  * <pre class="code">
@@ -29,7 +29,6 @@ import java.lang.annotation.*;
  * public class SampleRedisConfig implements InitializingBean {
  *   private int expireSeconds;
  *   private String clusterNodes;
- *   private int commandTimeout;
  *   private Map<String, String> someMap = Maps.newLinkedHashMap();
  *   private List<String> someList = Lists.newLinkedList();
  *   public void setExpireSeconds(int expireSeconds) {
@@ -37,9 +36,6 @@ import java.lang.annotation.*;
  *   }
  *   public void setClusterNodes(String clusterNodes) {
  *     this.clusterNodes = clusterNodes;
- *   }
- *   public void setCommandTimeout(int commandTimeout) {
- *     this.commandTimeout = commandTimeout;
  *   }
  *   public Map<String, String> getSomeMap() {
  *     return someMap;
@@ -50,36 +46,9 @@ import java.lang.annotation.*;
  * }
  * </pre>
  *
- *
- * You may set up data like the following in Apollo: <br /><br /> Properties Sample:
- * application.properties
- * <pre>
- * redis.cache.expireSeconds = 100
- * redis.cache.clusterNodes = 1,2
- * redis.cache.commandTimeout = 50
- * redis.cache.someMap.key1 = a
- * redis.cache.someMap.key2 = b
- * redis.cache.someList[0] = c
- * redis.cache.someList[1] = d
- * </pre>
- *
- * Yaml Sample: application.yaml
- * <pre>
- * redis:
- *   cache:
- *     expireSeconds: 100
- *     clusterNodes: 1,2
- *     commandTimeout: 50
- *     someMap:
- *       key1: a
- *       key2: b
- *     someList:
- *     - c
- *     - d
- * </pre>
- *
  * Ensure <code>apollo.autoRefreshConfigurationProperties</code> should be true.<br />
- * In Spring Cloud environment, <code>@RefreshScope<code> can replace this annotation to refresh `ConfigurationProperties`.
+ * In Spring Cloud environment, <code>org.springframework.cloud.context.config.annotation.RefreshScope<code> can replace this annotation to refresh ConfigurationProperties.
+ * Before refreshing ConfigurationProperties, all validators in the bean will be checked. If they do not meet the requirements, the entire bean will stop refreshing and report an error.
  *
  * @author licheng
  */

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/SpringConfigurationPropertiesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/annotation/SpringConfigurationPropertiesProcessor.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.spring.annotation;
+
+import com.ctrip.framework.apollo.build.ApolloInjector;
+import com.ctrip.framework.apollo.spring.property.SpringConfigurationPropertyRegistry;
+import com.ctrip.framework.apollo.spring.util.SpringInjector;
+import com.ctrip.framework.apollo.util.ConfigUtil;
+import java.lang.annotation.Annotation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+/**
+ * Configuration properties processor
+ *
+ * @author licheng
+ */
+public class SpringConfigurationPropertiesProcessor implements BeanPostProcessor,
+    ApplicationContextAware {
+
+  private static final Logger logger = LoggerFactory.getLogger(
+      SpringConfigurationPropertiesProcessor.class);
+  private static final String REFRESH_SCOPE_NAME = "org.springframework.cloud.context.config.annotation.RefreshScope";
+
+  private final ConfigUtil configUtil;
+  private final SpringConfigurationPropertyRegistry springConfigurationPropertyRegistry;
+  private AutowireCapableBeanFactory beanFactory;
+  private boolean supportAutowireCapableBeanFactory = false;
+
+  public SpringConfigurationPropertiesProcessor() {
+    springConfigurationPropertyRegistry = SpringInjector.getInstance(
+        SpringConfigurationPropertyRegistry.class);
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+  }
+
+  @Override
+  public Object postProcessBeforeInitialization(Object bean, String beanName) {
+    if (!supportAutowireCapableBeanFactory) {
+      return bean;
+    }
+    Class<?> clazz = bean.getClass();
+    ConfigurationProperties configurationPropertiesAnnotation = clazz.getDeclaredAnnotation(
+        ConfigurationProperties.class);
+    // match beans with annotated `@ConfigurationProperties` and `@ApolloConfigurationPropertiesRefresh`,
+    // or `@ConfigurationProperties` and `@RefreshScope`
+    if (configUtil.isAutoRefreshConfigurationPropertiesEnabled()
+        && configurationPropertiesAnnotation != null) {
+      ApolloConfigurationPropertiesRefresh apolloConfigurationPropertiesRefreshAnnotation = clazz.getDeclaredAnnotation(
+          ApolloConfigurationPropertiesRefresh.class);
+      if (apolloConfigurationPropertiesRefreshAnnotation != null || isRefreshScope(
+          clazz.getDeclaredAnnotations())) {
+        String prefix = configurationPropertiesAnnotation.prefix();
+        // cache prefix and bean name
+        springConfigurationPropertyRegistry.register(this.beanFactory, prefix, beanName);
+        logger.debug("Monitoring bean {}", beanName);
+      }
+    }
+    return bean;
+  }
+
+  private boolean isRefreshScope(Annotation[] annotations) {
+    for (Annotation annotation : annotations) {
+      if (annotation.annotationType().getName().equals(REFRESH_SCOPE_NAME)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    try {
+      this.beanFactory = applicationContext.getAutowireCapableBeanFactory();
+      this.supportAutowireCapableBeanFactory = true;
+    } catch (IllegalStateException e) {
+      logger.warn(
+          "Failed to init SpringConfigurationPropertiesProcessor", e);
+    }
+  }
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoRefreshConfigurationPropertiesListener.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/AutoRefreshConfigurationPropertiesListener.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.spring.property;
+
+import com.ctrip.framework.apollo.spring.events.ApolloConfigChangeEvent;
+import com.ctrip.framework.apollo.spring.util.SpringInjector;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationListener;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * @author licheng
+ * @see org.springframework.context.ApplicationContext#getAutowireCapableBeanFactory()
+ */
+public class AutoRefreshConfigurationPropertiesListener implements
+    ApplicationListener<ApolloConfigChangeEvent>,
+    ApplicationContextAware {
+
+  private static final Logger logger = LoggerFactory.getLogger(
+      AutoRefreshConfigurationPropertiesListener.class);
+
+  private AutowireCapableBeanFactory beanFactory;
+  private boolean supportAutowireCapableBeanFactory = false;
+  private final SpringConfigurationPropertyRegistry springConfigurationPropertyRegistry;
+
+  public AutoRefreshConfigurationPropertiesListener() {
+    this.springConfigurationPropertyRegistry = SpringInjector.getInstance(
+        SpringConfigurationPropertyRegistry.class);
+  }
+
+
+  @Override
+  public void onApplicationEvent(ApolloConfigChangeEvent event) {
+    if (!supportAutowireCapableBeanFactory) {
+      return;
+    }
+    Set<String> keys = event.getConfigChangeEvent().changedKeys();
+    if (CollectionUtils.isEmpty(keys)) {
+      return;
+    }
+    Set<String> targetBeanName = new HashSet<>();
+    for (String key : keys) {
+      // 1. check whether the changed key is relevant
+      Collection<String> targetCollection = springConfigurationPropertyRegistry.get(beanFactory,
+          key);
+      if (targetCollection != null) {
+        // ensure each bean refreshed once
+        targetBeanName.addAll(targetCollection);
+      }
+    }
+    // 2. update the configuration properties
+    for (String beanName : targetBeanName) {
+      refreshConfigurationProperties(beanFactory, beanName);
+    }
+  }
+
+  private void refreshConfigurationProperties(AutowireCapableBeanFactory beanFactory,
+      String beanName) {
+    try {
+      springConfigurationPropertyRegistry.refresh(beanFactory, beanName);
+      logger.info("Auto update apollo changed configuration properties successfully, bean: {}",
+          beanName);
+    } catch (Throwable ex) {
+      logger.error("Auto update apollo changed configuration properties failed, {}",
+          beanName, ex);
+    }
+  }
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    try {
+      this.beanFactory = applicationContext.getAutowireCapableBeanFactory();
+      this.supportAutowireCapableBeanFactory = true;
+    } catch (IllegalStateException e) {
+      logger.warn(
+          "Failed to init AutoRefreshConfigurationPropertiesListener", e);
+    }
+  }
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringConfigurationPropertyRegistry.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringConfigurationPropertyRegistry.java
@@ -31,19 +31,11 @@ import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 public class SpringConfigurationPropertyRegistry {
 
   private final Map<AutowireCapableBeanFactory, Multimap<String, String>> registry = Maps.newConcurrentMap();
-  private final Object LOCK = new Object();
 
   public void register(AutowireCapableBeanFactory beanFactory, String prefix,
       String beanName) {
-    if (!registry.containsKey(beanFactory)) {
-      synchronized (LOCK) {
-        if (!registry.containsKey(beanFactory)) {
-          // ensure no repeat bean names in same prefix
-          registry.put(beanFactory, Multimaps.synchronizedSetMultimap(HashMultimap.create()));
-        }
-      }
-    }
-    registry.get(beanFactory).put(prefix, beanName);
+    registry.computeIfAbsent(beanFactory,
+        k -> Multimaps.synchronizedSetMultimap(HashMultimap.create())).put(prefix, beanName);
   }
 
   public Collection<String> get(AutowireCapableBeanFactory beanFactory, String key) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringConfigurationPropertyRegistry.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringConfigurationPropertyRegistry.java
@@ -23,22 +23,22 @@ import com.google.common.collect.Multimaps;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
-import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.BeanFactory;
 
 /**
  * @author licheng
  */
 public class SpringConfigurationPropertyRegistry {
 
-  private final Map<AutowireCapableBeanFactory, Multimap<String, String>> registry = Maps.newConcurrentMap();
+  private final Map<BeanFactory, Multimap<String, String>> registry = Maps.newConcurrentMap();
 
-  public void register(AutowireCapableBeanFactory beanFactory, String prefix,
+  public void register(BeanFactory beanFactory, String prefix,
       String beanName) {
     registry.computeIfAbsent(beanFactory,
         k -> Multimaps.synchronizedSetMultimap(HashMultimap.create())).put(prefix, beanName);
   }
 
-  public Collection<String> get(AutowireCapableBeanFactory beanFactory, String key) {
+  public Collection<String> get(BeanFactory beanFactory, String key) {
     Multimap<String, String> beanNameMap = registry.get(beanFactory);
     if (beanNameMap == null) {
       return null;
@@ -52,11 +52,4 @@ public class SpringConfigurationPropertyRegistry {
     }
     return targetCollection;
   }
-
-  public void refresh(AutowireCapableBeanFactory beanFactory, String beanName) {
-    Object bean = beanFactory.getBean(beanName);
-    beanFactory.destroyBean(bean);
-    beanFactory.initializeBean(bean, beanName);
-  }
-
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringConfigurationPropertyRegistry.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringConfigurationPropertyRegistry.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.spring.property;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+
+/**
+ * @author licheng
+ */
+public class SpringConfigurationPropertyRegistry {
+
+  private final Map<AutowireCapableBeanFactory, Multimap<String, String>> registry = Maps.newConcurrentMap();
+  private final Object LOCK = new Object();
+
+  public void register(AutowireCapableBeanFactory beanFactory, String prefix,
+      String beanName) {
+    if (!registry.containsKey(beanFactory)) {
+      synchronized (LOCK) {
+        if (!registry.containsKey(beanFactory)) {
+          // ensure no repeat bean names in same prefix
+          registry.put(beanFactory, Multimaps.synchronizedSetMultimap(HashMultimap.create()));
+        }
+      }
+    }
+    registry.get(beanFactory).put(prefix, beanName);
+  }
+
+  public Collection<String> get(AutowireCapableBeanFactory beanFactory, String key) {
+    Multimap<String, String> beanNameMap = registry.get(beanFactory);
+    if (beanNameMap == null) {
+      return null;
+    }
+    // get all prefix matches beans
+    Collection<String> targetCollection = new HashSet<>();
+    for (String prefix : beanNameMap.keySet()) {
+      if (key.startsWith(prefix)) {
+        targetCollection.addAll(beanNameMap.get(prefix));
+      }
+    }
+    return targetCollection;
+  }
+
+  public void refresh(AutowireCapableBeanFactory beanFactory, String beanName) {
+    Object bean = beanFactory.getBean(beanName);
+    beanFactory.destroyBean(bean);
+    beanFactory.initializeBean(bean, beanName);
+  }
+
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultApolloConfigRegistrarHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultApolloConfigRegistrarHelper.java
@@ -19,8 +19,10 @@ package com.ctrip.framework.apollo.spring.spi;
 import com.ctrip.framework.apollo.core.spi.Ordered;
 import com.ctrip.framework.apollo.spring.annotation.ApolloAnnotationProcessor;
 import com.ctrip.framework.apollo.spring.annotation.EnableApolloConfig;
+import com.ctrip.framework.apollo.spring.annotation.SpringConfigurationPropertiesProcessor;
 import com.ctrip.framework.apollo.spring.annotation.SpringValueProcessor;
 import com.ctrip.framework.apollo.spring.config.PropertySourcesProcessor;
+import com.ctrip.framework.apollo.spring.property.AutoRefreshConfigurationPropertiesListener;
 import com.ctrip.framework.apollo.spring.property.AutoUpdateConfigChangeListener;
 import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
 import com.ctrip.framework.apollo.spring.util.BeanRegistrationUtil;
@@ -57,10 +59,12 @@ public class DefaultApolloConfigRegistrarHelper implements ApolloConfigRegistrar
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesPlaceholderConfigurer.class,
             propertySourcesPlaceholderPropertyValues);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, AutoUpdateConfigChangeListener.class);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, AutoRefreshConfigurationPropertiesListener.class);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesProcessor.class);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloAnnotationProcessor.class);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueProcessor.class);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueDefinitionProcessor.class);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringConfigurationPropertiesProcessor.class);
   }
 
   private String[] resolveNamespaces(String[] namespaces) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultConfigPropertySourcesProcessorHelper.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/spi/DefaultConfigPropertySourcesProcessorHelper.java
@@ -18,7 +18,9 @@ package com.ctrip.framework.apollo.spring.spi;
 
 import com.ctrip.framework.apollo.core.spi.Ordered;
 import com.ctrip.framework.apollo.spring.annotation.ApolloAnnotationProcessor;
+import com.ctrip.framework.apollo.spring.annotation.SpringConfigurationPropertiesProcessor;
 import com.ctrip.framework.apollo.spring.annotation.SpringValueProcessor;
+import com.ctrip.framework.apollo.spring.property.AutoRefreshConfigurationPropertiesListener;
 import com.ctrip.framework.apollo.spring.property.AutoUpdateConfigChangeListener;
 import com.ctrip.framework.apollo.spring.property.SpringValueDefinitionProcessor;
 import com.ctrip.framework.apollo.spring.util.BeanRegistrationUtil;
@@ -39,9 +41,10 @@ public class DefaultConfigPropertySourcesProcessorHelper implements ConfigProper
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, PropertySourcesPlaceholderConfigurer.class,
             propertySourcesPlaceholderPropertyValues);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, AutoUpdateConfigChangeListener.class);
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, AutoRefreshConfigurationPropertiesListener.class);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, ApolloAnnotationProcessor.class);
     BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringValueProcessor.class);
-
+    BeanRegistrationUtil.registerBeanDefinitionIfNotExists(registry, SpringConfigurationPropertiesProcessor.class);
     processSpringValueDefinition(registry);
   }
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/SpringInjector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/SpringInjector.java
@@ -19,6 +19,7 @@ package com.ctrip.framework.apollo.spring.util;
 import com.ctrip.framework.apollo.exceptions.ApolloConfigException;
 import com.ctrip.framework.apollo.spring.config.ConfigPropertySourceFactory;
 import com.ctrip.framework.apollo.spring.property.PlaceholderHelper;
+import com.ctrip.framework.apollo.spring.property.SpringConfigurationPropertyRegistry;
 import com.ctrip.framework.apollo.spring.property.SpringValueRegistry;
 import com.ctrip.framework.apollo.tracer.Tracer;
 import com.google.inject.AbstractModule;
@@ -64,6 +65,7 @@ public class SpringInjector {
       bind(PlaceholderHelper.class).in(Singleton.class);
       bind(ConfigPropertySourceFactory.class).in(Singleton.class);
       bind(SpringValueRegistry.class).in(Singleton.class);
+      bind(SpringConfigurationPropertyRegistry.class).in(Singleton.class);
     }
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ConfigUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/ConfigUtil.java
@@ -66,6 +66,7 @@ public class ConfigUtil {
   private TimeUnit configCacheExpireTimeUnit = TimeUnit.MINUTES;//1 minute
   private long longPollingInitialDelayInMills = 2000;//2 seconds
   private boolean autoUpdateInjectedSpringProperties = true;
+  private boolean autoRefreshConfigurationProperties = true;
   private final RateLimiter warnLogRateLimiter;
   private boolean propertiesOrdered = false;
   private boolean propertyNamesCacheEnabled = false;
@@ -82,6 +83,7 @@ public class ConfigUtil {
     initMaxConfigCacheSize();
     initLongPollingInitialDelayInMills();
     initAutoUpdateInjectedSpringProperties();
+    initAutoRefreshConfigurationProperties();
     initPropertiesOrdered();
     initPropertyNamesCacheEnabled();
     initPropertyFileCacheEnabled();
@@ -438,6 +440,23 @@ public class ConfigUtil {
 
   public boolean isAutoUpdateInjectedSpringPropertiesEnabled() {
     return autoUpdateInjectedSpringProperties;
+  }
+
+  private void initAutoRefreshConfigurationProperties() {
+    // 1. Get from System Property
+    String enableAutoRefresh = System.getProperty("apollo.autoRefreshConfigurationProperties");
+    if (Strings.isNullOrEmpty(enableAutoRefresh)) {
+      // 2. Get from app.properties
+      enableAutoRefresh = Foundation.app()
+          .getProperty("apollo.autoRefreshConfigurationProperties", null);
+    }
+    if (!Strings.isNullOrEmpty(enableAutoRefresh)) {
+      autoRefreshConfigurationProperties = Boolean.parseBoolean(enableAutoRefresh.trim());
+    }
+  }
+
+  public boolean isAutoRefreshConfigurationPropertiesEnabled() {
+    return autoRefreshConfigurationProperties;
   }
 
   private void initPropertiesOrdered() {


### PR DESCRIPTION
## What's the purpose of this PR

Add configuration properties refresh.

## Which issue(s) this PR fixes:


## Brief changelog

1. Add annotation `@ApolloConfiguringPropertiesRefresh` to refresh ConfigurationProperties.
2. In Spring Cloud, `@RefreshScope` can replace `@ApolloConfiguringPropertiesRefresh` to refresh ConfigurationProperties.
3. Add `apollo.autoRefreshConfigurationProperties` to control whether refresh effect

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced the `@ApolloConfigurationPropertiesRefresh` annotation to enable seamless refreshing of configuration properties in Spring applications.
  - Added functionalities for automatic management and refresh of beans based on Apollo configuration changes to improve application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->