### PR TITLE
feat: openapi query namespace support not fill item

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Apollo Java 2.4.0
 
 ------------------
 * [Fix the Cannot enhance @Configuration bean definition issue](https://github.com/apolloconfig/apollo-java/pull/82)
+* [Feature openapi query namespace support not fill item](https://github.com/apolloconfig/apollo-java/pull/83)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/4?closed=1)

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/NamespaceOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/NamespaceOpenApiService.java
@@ -26,8 +26,30 @@ import java.util.List;
  */
 public interface NamespaceOpenApiService {
 
+  /**
+   * @deprecated use {@link NamespaceOpenApiService#getNamespace(String, String, String, String, boolean)} instead
+   */
+  default OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName) {
+    return getNamespace(appId, env, clusterName, namespaceName, true);
+  }
+
+  /**
+   * Retrieves a single namespace
+   * @since 2.4.0
+   */
   OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName, boolean fillItemDetail);
 
+  /**
+   * @deprecated use {@link NamespaceOpenApiService#getNamespaces(String, String, String, boolean)} instead
+   */
+  default List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName) {
+    return getNamespaces(appId, env, clusterName, true);
+  }
+
+  /**
+   * Retrieves a list namespaces
+   * @since 2.4.0
+   */
   List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName, boolean fillItemDetail);
 
   OpenAppNamespaceDTO createAppNamespace(OpenAppNamespaceDTO appNamespaceDTO);

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/NamespaceOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/NamespaceOpenApiService.java
@@ -26,9 +26,9 @@ import java.util.List;
  */
 public interface NamespaceOpenApiService {
 
-  OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName);
+  OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName, boolean fillItemDetail);
 
-  List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName);
+  List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName, boolean fillItemDetail);
 
   OpenAppNamespaceDTO createAppNamespace(OpenAppNamespaceDTO appNamespaceDTO);
 

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/NamespaceOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/NamespaceOpenApiService.java
@@ -26,9 +26,6 @@ import java.util.List;
  */
 public interface NamespaceOpenApiService {
 
-  /**
-   * @deprecated use {@link NamespaceOpenApiService#getNamespace(String, String, String, String, boolean)} instead
-   */
   default OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName) {
     return getNamespace(appId, env, clusterName, namespaceName, true);
   }
@@ -39,9 +36,6 @@ public interface NamespaceOpenApiService {
    */
   OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName, boolean fillItemDetail);
 
-  /**
-   * @deprecated use {@link NamespaceOpenApiService#getNamespaces(String, String, String, boolean)} instead
-   */
   default List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName) {
     return getNamespaces(appId, env, clusterName, true);
   }

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
@@ -99,11 +99,8 @@ public class ApolloOpenApiClient {
     return appService.getAppsInfo(appIds);
   }
 
-  /**
-   * @deprecated use {@link ApolloOpenApiClient#getNamespaces(String, String, String, boolean)} instead
-   */
   public List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName) {
-    return namespaceService.getNamespaces(appId, env, clusterName, true);
+    return namespaceService.getNamespaces(appId, env, clusterName);
   }
 
   /**
@@ -132,11 +129,8 @@ public class ApolloOpenApiClient {
     return clusterService.createCluster(env, openClusterDTO);
   }
 
-  /**
-   * @deprecated use {@link ApolloOpenApiClient#getNamespace(String, String, String, String, boolean)} instead
-   */
   public OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName) {
-    return namespaceService.getNamespace(appId, env, clusterName, namespaceName, true);
+    return namespaceService.getNamespace(appId, env, clusterName, namespaceName);
   }
 
   /**

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
@@ -100,10 +100,18 @@ public class ApolloOpenApiClient {
   }
 
   /**
-   * Get the namespaces
+   * @deprecated use {@link ApolloOpenApiClient#getNamespaces(String, String, String, boolean)} instead
    */
   public List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName) {
-    return namespaceService.getNamespaces(appId, env, clusterName);
+    return namespaceService.getNamespaces(appId, env, clusterName, true);
+  }
+
+  /**
+   * Get the namespaces
+   * @since 2.4.0
+   */
+  public List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName, boolean fillItemDetail) {
+    return namespaceService.getNamespaces(appId, env, clusterName, fillItemDetail);
   }
 
   /**
@@ -125,10 +133,18 @@ public class ApolloOpenApiClient {
   }
 
   /**
-   * Get the namespace
+   * @deprecated use {@link ApolloOpenApiClient#getNamespace(String, String, String, String, boolean)} instead
    */
   public OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName) {
-    return namespaceService.getNamespace(appId, env, clusterName, namespaceName);
+    return namespaceService.getNamespace(appId, env, clusterName, namespaceName, true);
+  }
+
+  /**
+   * Get the namespace
+   * @since 2.4.0
+   */
+  public OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName, boolean fillItemDetail) {
+    return namespaceService.getNamespace(appId, env, clusterName, namespaceName, fillItemDetail);
   }
 
   /**

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiService.java
@@ -41,7 +41,7 @@ public class NamespaceOpenApiService extends AbstractOpenApiService implements
   }
 
   @Override
-  public OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName) {
+  public OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName, boolean fillItemDetail) {
     if (Strings.isNullOrEmpty(clusterName)) {
       clusterName = ConfigConsts.CLUSTER_NAME_DEFAULT;
     }
@@ -58,6 +58,8 @@ public class NamespaceOpenApiService extends AbstractOpenApiService implements
         .clustersPathVal(clusterName)
         .namespacesPathVal(namespaceName);
 
+    pathBuilder.addParam("fillItemDetail", fillItemDetail);
+
     try (CloseableHttpResponse response = get(pathBuilder)) {
       return gson.fromJson(EntityUtils.toString(response.getEntity()), OpenNamespaceDTO.class);
     } catch (Throwable ex) {
@@ -68,7 +70,7 @@ public class NamespaceOpenApiService extends AbstractOpenApiService implements
   }
 
   @Override
-  public List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName) {
+  public List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName, boolean fillItemDetail) {
     if (Strings.isNullOrEmpty(clusterName)) {
       clusterName = ConfigConsts.CLUSTER_NAME_DEFAULT;
     }
@@ -81,6 +83,8 @@ public class NamespaceOpenApiService extends AbstractOpenApiService implements
         .appsPathVal(appId)
         .clustersPathVal(clusterName)
         .customResource("namespaces");
+
+    pathBuilder.addParam("fillItemDetail", fillItemDetail);
 
     try (CloseableHttpResponse response = get(pathBuilder)) {
       return gson.fromJson(EntityUtils.toString(response.getEntity()), OPEN_NAMESPACE_DTO_LIST_TYPE);

--- a/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiServiceTest.java
+++ b/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiServiceTest.java
@@ -58,23 +58,16 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
 
   @Test
   public void testGetNamespace() throws Exception {
-    final ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
-
-    namespaceOpenApiService.getNamespace(someAppId, someEnv, someCluster, someNamespace);
-
-    verify(httpClient, times(1)).execute(request.capture());
-
-    HttpGet get = request.getValue();
-
-    assertEquals(String
-        .format("%s/envs/%s/apps/%s/clusters/%s/namespaces/%s?fillItemDetail=%s", someBaseUrl, someEnv, someAppId, someCluster,
-            someNamespace, fillItemDetail), get.getURI().toString());
+    verifyGetNamespace(true);
   }
 
   @Test
   public void testGetNamespaceWithFillItemDetailFalse() throws Exception {
+    verifyGetNamespace(false);
+  }
 
-    fillItemDetail = false;
+  private void verifyGetNamespace(boolean fillItemDetailValue) throws Exception {
+    fillItemDetail = fillItemDetailValue;
 
     final ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
 
@@ -84,9 +77,9 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
 
     HttpGet get = request.getValue();
 
-    assertEquals(String
-                     .format("%s/envs/%s/apps/%s/clusters/%s/namespaces/%s?fillItemDetail=%s", someBaseUrl, someEnv, someAppId, someCluster,
-                             someNamespace, fillItemDetail), get.getURI().toString());
+    assertEquals(String.format("%s/envs/%s/apps/%s/clusters/%s/namespaces/%s?fillItemDetail=%s",
+                               someBaseUrl, someEnv, someAppId, someCluster, someNamespace, fillItemDetail),
+                 get.getURI().toString());
   }
 
   @Test(expected = RuntimeException.class)
@@ -96,28 +89,26 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
     namespaceOpenApiService.getNamespace(someAppId, someEnv, someCluster, someNamespace, true);
   }
 
+  @Test(expected = RuntimeException.class)
+  public void testGetNamespaceWithErrorAndFillItemDetailFalse() throws Exception {
+    when(statusLine.getStatusCode()).thenReturn(404);
+
+    namespaceOpenApiService.getNamespace(someAppId, someEnv, someCluster, someNamespace, false);
+  }
+
   @Test
   public void testGetNamespaces() throws Exception {
-    StringEntity responseEntity = new StringEntity("[]");
-    when(someHttpResponse.getEntity()).thenReturn(responseEntity);
-
-    final ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
-
-    namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster);
-
-    verify(httpClient, times(1)).execute(request.capture());
-
-    HttpGet get = request.getValue();
-
-    assertEquals(String
-            .format("%s/envs/%s/apps/%s/clusters/%s/namespaces?fillItemDetail=%s", someBaseUrl, someEnv, someAppId, someCluster, fillItemDetail),
-        get.getURI().toString());
+    verifyGetNamespace(true);
   }
 
   @Test
   public void testGetNamespacesWithFillItemDetailFalse() throws Exception {
+    verifyGetNamespace(false);
+  }
 
-    fillItemDetail = false;
+
+  private void verifyGetNamespaces(boolean fillItemDetailValue) throws Exception {
+    fillItemDetail = fillItemDetailValue;
 
     StringEntity responseEntity = new StringEntity("[]");
     when(someHttpResponse.getEntity()).thenReturn(responseEntity);
@@ -140,6 +131,13 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
     when(statusLine.getStatusCode()).thenReturn(404);
 
     namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster, true);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testGetNamespacesWithErrorAndFillItemDetailFalse() throws Exception {
+    when(statusLine.getStatusCode()).thenReturn(404);
+
+    namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster, false);
   }
 
   @Test

--- a/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiServiceTest.java
+++ b/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiServiceTest.java
@@ -58,7 +58,7 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
   public void testGetNamespace() throws Exception {
     final ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
 
-    namespaceOpenApiService.getNamespace(someAppId, someEnv, someCluster, someNamespace);
+    namespaceOpenApiService.getNamespace(someAppId, someEnv, someCluster, someNamespace, true);
 
     verify(httpClient, times(1)).execute(request.capture());
 
@@ -73,7 +73,7 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
   public void testGetNamespaceWithError() throws Exception {
     when(statusLine.getStatusCode()).thenReturn(404);
 
-    namespaceOpenApiService.getNamespace(someAppId, someEnv, someCluster, someNamespace);
+    namespaceOpenApiService.getNamespace(someAppId, someEnv, someCluster, someNamespace, true);
   }
 
   @Test
@@ -83,7 +83,7 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
 
     final ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
 
-    namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster);
+    namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster, true);
 
     verify(httpClient, times(1)).execute(request.capture());
 
@@ -98,7 +98,7 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
   public void testGetNamespacesWithError() throws Exception {
     when(statusLine.getStatusCode()).thenReturn(404);
 
-    namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster);
+    namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster, true);
   }
 
   @Test

--- a/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiServiceTest.java
+++ b/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiServiceTest.java
@@ -37,6 +37,7 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
   private String someEnv;
   private String someCluster;
   private String someNamespace;
+  private boolean fillItemDetail;
 
   @Override
   @Before
@@ -47,6 +48,7 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
     someEnv = "someEnv";
     someCluster = "someCluster";
     someNamespace = "someNamespace";
+    fillItemDetail = true;
 
     StringEntity responseEntity = new StringEntity("{}");
     when(someHttpResponse.getEntity()).thenReturn(responseEntity);
@@ -58,15 +60,33 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
   public void testGetNamespace() throws Exception {
     final ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
 
-    namespaceOpenApiService.getNamespace(someAppId, someEnv, someCluster, someNamespace, true);
+    namespaceOpenApiService.getNamespace(someAppId, someEnv, someCluster, someNamespace);
 
     verify(httpClient, times(1)).execute(request.capture());
 
     HttpGet get = request.getValue();
 
     assertEquals(String
-        .format("%s/envs/%s/apps/%s/clusters/%s/namespaces/%s", someBaseUrl, someEnv, someAppId, someCluster,
-            someNamespace), get.getURI().toString());
+        .format("%s/envs/%s/apps/%s/clusters/%s/namespaces/%s?fillItemDetail=%s", someBaseUrl, someEnv, someAppId, someCluster,
+            someNamespace, fillItemDetail), get.getURI().toString());
+  }
+
+  @Test
+  public void testGetNamespaceWithFillItemDetailFalse() throws Exception {
+
+    fillItemDetail = false;
+
+    final ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
+
+    namespaceOpenApiService.getNamespace(someAppId, someEnv, someCluster, someNamespace, fillItemDetail);
+
+    verify(httpClient, times(1)).execute(request.capture());
+
+    HttpGet get = request.getValue();
+
+    assertEquals(String
+                     .format("%s/envs/%s/apps/%s/clusters/%s/namespaces/%s?fillItemDetail=%s", someBaseUrl, someEnv, someAppId, someCluster,
+                             someNamespace, fillItemDetail), get.getURI().toString());
   }
 
   @Test(expected = RuntimeException.class)
@@ -83,15 +103,36 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
 
     final ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
 
-    namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster, true);
+    namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster);
 
     verify(httpClient, times(1)).execute(request.capture());
 
     HttpGet get = request.getValue();
 
     assertEquals(String
-            .format("%s/envs/%s/apps/%s/clusters/%s/namespaces", someBaseUrl, someEnv, someAppId, someCluster),
+            .format("%s/envs/%s/apps/%s/clusters/%s/namespaces?fillItemDetail=%s", someBaseUrl, someEnv, someAppId, someCluster, fillItemDetail),
         get.getURI().toString());
+  }
+
+  @Test
+  public void testGetNamespacesWithFillItemDetailFalse() throws Exception {
+
+    fillItemDetail = false;
+
+    StringEntity responseEntity = new StringEntity("[]");
+    when(someHttpResponse.getEntity()).thenReturn(responseEntity);
+
+    final ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
+
+    namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster, fillItemDetail);
+
+    verify(httpClient, times(1)).execute(request.capture());
+
+    HttpGet get = request.getValue();
+
+    assertEquals(String
+                     .format("%s/envs/%s/apps/%s/clusters/%s/namespaces?fillItemDetail=%s", someBaseUrl, someEnv, someAppId, someCluster, fillItemDetail),
+                 get.getURI().toString());
   }
 
   @Test(expected = RuntimeException.class)


### PR DESCRIPTION
## What's the purpose of this PR

XXXXX

## Which issue(s) this PR fixes:
Fixes [apolloconfig/apollo/issues/5243](https://github.com/apolloconfig/apollo/issues/5243)

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced API methods for retrieving namespaces and specific namespace details, allowing users to specify the level of detail for item retrieval.
	- Added documentation for the new feature related to "openapi query namespace support not fill item."

- **Bug Fixes**
	- Deprecated older method signatures to streamline usage and ensure consistency with new parameters.

- **Tests**
	- Updated test cases to align with the revised method signatures for improved accuracy in testing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->