### PR TITLE
upgrade cache action to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,12 @@ jobs:
       with:
         java-version: ${{ matrix.jdk }}
     - name: Cache Maven packages
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: JDK 8
       if: matrix.jdk == '8'
       run: mvn -B clean package -P travis jacoco:report -Dmaven.gitcommitid.skip=true


### PR DESCRIPTION
## What's the purpose of this PR

According to the [github annoucement](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/), the `actions/cache@v1` will be deprecated in 2025/02, so we need to upgrade the version.

## Brief changelog

* upgrade the cache action version to v4

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated caching configuration for Maven dependencies in the build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->