### PR TITLE
fix the concurrent issue in SpringValueRegistry.scanAndClean

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Apollo Java 2.4.0
 * [Feature Support Kubernetes ConfigMap cache for Apollo java, golang client](https://github.com/apolloconfig/apollo-java/pull/79)
 * [Feature support pulling configuration information from multiple AppIds](https://github.com/apolloconfig/apollo-java/pull/70)
 * [Fix monitor arg cause npe](https://github.com/apolloconfig/apollo-java/pull/86)
+* [Fix the concurrent issue in SpringValueRegistry.scanAndClean](https://github.com/apolloconfig/apollo-java/pull/95)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/4?closed=1)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringValueRegistry.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/property/SpringValueRegistry.java
@@ -84,12 +84,15 @@ public class SpringValueRegistry {
     Iterator<Multimap<String, SpringValue>> iterator = registry.values().iterator();
     while (!Thread.currentThread().isInterrupted() && iterator.hasNext()) {
       Multimap<String, SpringValue> springValues = iterator.next();
-      Iterator<Entry<String, SpringValue>> springValueIterator = springValues.entries().iterator();
-      while (springValueIterator.hasNext()) {
-        Entry<String, SpringValue> springValue = springValueIterator.next();
-        if (!springValue.getValue().isTargetBeanValid()) {
-          // clear unused spring values
-          springValueIterator.remove();
+      synchronized (springValues) {
+        Iterator<Entry<String, SpringValue>> springValueIterator = springValues.entries()
+            .iterator();
+        while (springValueIterator.hasNext()) {
+          Entry<String, SpringValue> springValue = springValueIterator.next();
+          if (!springValue.getValue().isTargetBeanValid()) {
+            // clear unused spring values
+            springValueIterator.remove();
+          }
         }
       }
     }


### PR DESCRIPTION
## What's the purpose of this PR

fix the concurrent issue in SpringValueRegistry.scanAndClean

## Which issue(s) this PR fixes:
Fixes https://github.com/apolloconfig/apollo/issues/5296, https://github.com/apolloconfig/apollo/issues/4355

## Brief changelog

* Synchronize the multimap in `scanAndClean`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new entry in the release notes addressing a concurrent issue in the SpringValueRegistry.
  
- **Bug Fixes**
	- Resolved a concurrent modification issue in the SpringValueRegistry.scanAndClean method, enhancing thread safety. 

- **Documentation**
	- Updated the CHANGES.md file with new entries detailing fixes and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->