### PR TITLE
feat: Provide a new open APl to return the organization list(#5349)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Apollo Java 2.5.0
 
 ------------------
 
-* 
+* [Feature Provide a new open APl to return the organization list](https://github.com/apolloconfig/apollo-java/pull/102)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/5?closed=1)

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/OrganizationOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/OrganizationOpenApiService.java
@@ -22,5 +22,9 @@ import java.util.List;
 
 public interface OrganizationOpenApiService {
 
+  /**
+   * Retrieves all organizations
+   * @since 2.5.0
+   */
     List<OpenOrganizationDto> getOrganizations();
 }

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/OrganizationOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/OrganizationOpenApiService.java
@@ -22,9 +22,9 @@ import java.util.List;
 
 public interface OrganizationOpenApiService {
 
-  /**
-   * Retrieves all organizations
-   * @since 2.5.0
-   */
+    /**
+     * Retrieves all organizations
+     * @since 2.5.0
+     */
     List<OpenOrganizationDto> getOrganizations();
 }

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/OrganizationOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/OrganizationOpenApiService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.api;
+
+import com.ctrip.framework.apollo.openapi.dto.OpenOrganizationDto;
+
+import java.util.List;
+
+public interface OrganizationOpenApiService {
+
+    List<OpenOrganizationDto> getOrganizations();
+}

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
@@ -22,6 +22,7 @@ import com.ctrip.framework.apollo.openapi.client.service.ClusterOpenApiService;
 import com.ctrip.framework.apollo.openapi.client.service.ItemOpenApiService;
 import com.ctrip.framework.apollo.openapi.client.service.NamespaceOpenApiService;
 import com.ctrip.framework.apollo.openapi.client.service.ReleaseOpenApiService;
+import com.ctrip.framework.apollo.openapi.client.service.OrganizationOpenApiService;
 import com.ctrip.framework.apollo.openapi.dto.*;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -45,6 +46,7 @@ public class ApolloOpenApiClient {
   private final String portalUrl;
   private final String token;
   private final AppOpenApiService appService;
+  private final OrganizationOpenApiService organizationOpenService;
   private final ItemOpenApiService itemService;
   private final ReleaseOpenApiService releaseService;
   private final NamespaceOpenApiService namespaceService;
@@ -54,7 +56,7 @@ public class ApolloOpenApiClient {
   private ApolloOpenApiClient(String portalUrl, String token, RequestConfig requestConfig) {
     this.portalUrl = portalUrl;
     this.token = token;
-    CloseableHttpClient client = HttpClients.custom().setDefaultRequestConfig(requestConfig)
+      CloseableHttpClient client = HttpClients.custom().setDefaultRequestConfig(requestConfig)
         .setDefaultHeaders(Lists.newArrayList(new BasicHeader("Authorization", token))).build();
 
     String baseUrl = this.portalUrl + ApolloOpenApiConstants.OPEN_API_V1_PREFIX;
@@ -63,6 +65,7 @@ public class ApolloOpenApiClient {
     namespaceService = new NamespaceOpenApiService(client, baseUrl, GSON);
     itemService = new ItemOpenApiService(client, baseUrl, GSON);
     releaseService = new ReleaseOpenApiService(client, baseUrl, GSON);
+    organizationOpenService = new OrganizationOpenApiService(client, baseUrl, GSON);
   }
 
   public void createApp(OpenCreateAppDTO req) {
@@ -82,6 +85,14 @@ public class ApolloOpenApiClient {
   public List<OpenAppDTO> getAllApps() {
     return appService.getAllApps();
   }
+
+  /**
+   * Get all  Organizations
+   */
+  public List<OpenOrganizationDto> getOrganization() {
+    return organizationOpenService.getOrganizations();
+  }
+
 
   /**
    * Get applications which can be operated by current open api client.

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
@@ -56,7 +56,7 @@ public class ApolloOpenApiClient {
   private ApolloOpenApiClient(String portalUrl, String token, RequestConfig requestConfig) {
     this.portalUrl = portalUrl;
     this.token = token;
-      CloseableHttpClient client = HttpClients.custom().setDefaultRequestConfig(requestConfig)
+    CloseableHttpClient client = HttpClients.custom().setDefaultRequestConfig(requestConfig)
         .setDefaultHeaders(Lists.newArrayList(new BasicHeader("Authorization", token))).build();
 
     String baseUrl = this.portalUrl + ApolloOpenApiConstants.OPEN_API_V1_PREFIX;

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
@@ -87,12 +87,11 @@ public class ApolloOpenApiClient {
   }
 
   /**
-   * Get all  Organizations
+   * Get all organizations
    */
-  public List<OpenOrganizationDto> getOrganization() {
+  public List<OpenOrganizationDto> getOrganizations() {
     return organizationOpenService.getOrganizations();
   }
-
 
   /**
    * Get applications which can be operated by current open api client.

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/OrganizationOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/OrganizationOpenApiService.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  */
-
 package com.ctrip.framework.apollo.openapi.client.service;
 
 import com.ctrip.framework.apollo.openapi.client.url.OpenApiPathBuilder;

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/OrganizationOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/OrganizationOpenApiService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.ctrip.framework.apollo.openapi.client.service;
+
+import com.ctrip.framework.apollo.openapi.client.url.OpenApiPathBuilder;
+import com.ctrip.framework.apollo.openapi.dto.OpenOrganizationDto;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class OrganizationOpenApiService extends AbstractOpenApiService implements
+        com.ctrip.framework.apollo.openapi.api.OrganizationOpenApiService{
+    public OrganizationOpenApiService(CloseableHttpClient client, String baseUrl, Gson gson) {
+        super(client, baseUrl, gson);
+    }
+
+    private static final Type ORGANIZATIONS_DTO_LIST_TYPE = new TypeToken<List<OpenOrganizationDto>>() {
+    }.getType();
+
+    @Override
+    public List<OpenOrganizationDto> getOrganizations() {
+        OpenApiPathBuilder pathBuilder = OpenApiPathBuilder.newBuilder()
+                .customResource("/organizations");
+
+        try (CloseableHttpResponse response = get(pathBuilder)) {
+            return gson.fromJson(EntityUtils.toString(response.getEntity()), ORGANIZATIONS_DTO_LIST_TYPE);
+        } catch (Throwable ex) {
+            throw new RuntimeException("get organizations information failed", ex);
+        }
+
+    }
+}
+

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/OrganizationOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/OrganizationOpenApiService.java
@@ -29,12 +29,13 @@ import java.util.List;
 
 public class OrganizationOpenApiService extends AbstractOpenApiService implements
         com.ctrip.framework.apollo.openapi.api.OrganizationOpenApiService{
+    private static final Type ORGANIZATIONS_DTO_LIST_TYPE = new TypeToken<List<OpenOrganizationDto>>() {
+    }.getType();
+
     public OrganizationOpenApiService(CloseableHttpClient client, String baseUrl, Gson gson) {
         super(client, baseUrl, gson);
     }
 
-    private static final Type ORGANIZATIONS_DTO_LIST_TYPE = new TypeToken<List<OpenOrganizationDto>>() {
-    }.getType();
 
     @Override
     public List<OpenOrganizationDto> getOrganizations() {

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/OrganizationOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/OrganizationOpenApiService.java
@@ -36,7 +36,6 @@ public class OrganizationOpenApiService extends AbstractOpenApiService implement
         super(client, baseUrl, gson);
     }
 
-
     @Override
     public List<OpenOrganizationDto> getOrganizations() {
         OpenApiPathBuilder pathBuilder = OpenApiPathBuilder.newBuilder()

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/dto/OpenOrganizationDto.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/dto/OpenOrganizationDto.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  */
-
 package com.ctrip.framework.apollo.openapi.dto;
 
 public class OpenOrganizationDto {

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/dto/OpenOrganizationDto.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/dto/OpenOrganizationDto.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.ctrip.framework.apollo.openapi.dto;
+
+public class OpenOrganizationDto {
+    private String orgId;
+    private String orgName;
+
+    public String getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
+    }
+
+    public String getOrgName() {
+        return orgName;
+    }
+
+    public void setOrgName(String orgName) {
+        this.orgName = orgName;
+    }
+
+    @Override
+    public String toString() {
+        return "OpenOrganizationDto{" +
+                "orgId='" + orgId + '\'' +
+                ", orgName='" + orgName + '\'' +
+                '}';
+    }
+}


### PR DESCRIPTION
## What's the purpose of this PR

feat: Provide a new open APl to return the organization list([#5349](https://github.com/apolloconfig/apollo/issues/5349))

## Which issue(s) this PR fixes:
[#5349](https://github.com/apolloconfig/apollo/issues/5349)

## Brief changelog

After updating the project, we can use this method like this way： 
```java
       String portalUrl = "http://localhost:8070"; // portal url
        String token = "25e545146773469d1b9874339849487dc89f28e6d6e0dbd75a1664cca3bb1ada"; // 申请的token
        ApolloOpenApiClient client = ApolloOpenApiClient.newBuilder()
                .withPortalUrl(portalUrl)
                .withToken(token)
                .build();
        client.getOrganization().forEach(System.out::println);
```
![PixPin_2025-03-25_22-07-06](https://github.com/user-attachments/assets/ff597eb5-a951-4c97-9513-a7a61c2b19e6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a capability to retrieve organization information directly via the API client.
	- Introduced a service that fetches a list of organizations.
	- Implemented a standardized representation for organization details.
	- Added a new open API to return the organization list in version 2.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->