### PR TITLE
feat: Support retry in open api client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Apollo Java 2.5.0
 
 * [Feature Provide a new open APl to return the organization list](https://github.com/apolloconfig/apollo-java/pull/102)
 * [Feature Added a new feature to get instance count by namespace.](https://github.com/apolloconfig/apollo-java/pull/103)
+* [Feature Support retry in open api client.](https://github.com/apolloconfig/apollo-java/pull/105)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/5?closed=1)

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/extend/ApolloStandardHttpRequestRetryHandler.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/extend/ApolloStandardHttpRequestRetryHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.client.extend;
+
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.http.HttpRequest;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+
+import javax.net.ssl.SSLException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Locale;
+
+/**
+ * @author zth9
+ * @date 2025-05-07
+ */
+public class ApolloStandardHttpRequestRetryHandler extends DefaultHttpRequestRetryHandler {
+
+  private final Set<String> idempotentMethods;
+
+  public ApolloStandardHttpRequestRetryHandler(int retryCount, IdempotentHttpMethod[] httpMethods) {
+    super(retryCount, false, Arrays.asList(
+        UnknownHostException.class,
+        ConnectException.class,
+        NoRouteToHostException.class,
+        SSLException.class));
+    this.idempotentMethods = new HashSet<>();
+    if (httpMethods == null || httpMethods.length == 0) {
+      // default set safe idempotent http method
+      httpMethods = IdempotentHttpMethod.safe();
+    }
+    for (IdempotentHttpMethod httpMethod : httpMethods) {
+      if (httpMethod == null) {
+        continue;
+      }
+      idempotentMethods.add(httpMethod.name());
+    }
+  }
+
+  @Override
+  protected boolean handleAsIdempotent(final HttpRequest request) {
+    String method = request.getRequestLine().getMethod().toUpperCase(Locale.ROOT);
+    return idempotentMethods.contains(method);
+  }
+}

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/extend/IdempotentHttpMethod.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/extend/IdempotentHttpMethod.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.client.extend;
+
+/**
+ * @author zth9
+ * @date 2025-05-11
+ */
+public enum IdempotentHttpMethod {
+  GET, HEAD, PUT, DELETE, OPTIONS, TRACE;
+
+  /**
+   * Usually, these methods are idempotent
+   */
+  public static IdempotentHttpMethod[] safe() {
+    return new IdempotentHttpMethod[]{GET, HEAD, OPTIONS, TRACE};
+  }
+
+  /**
+   * Standard HTTP idempotent method. While PUT and DELETE are technically idempotent, repeated
+   * requests can yield different responses—such as a 404 on a second delete
+   */
+  public static IdempotentHttpMethod[] standard() {
+    return new IdempotentHttpMethod[]{GET, HEAD, PUT, DELETE, OPTIONS, TRACE};
+  }
+}

--- a/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClientIntegrationTest.java
+++ b/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClientIntegrationTest.java
@@ -19,6 +19,7 @@ package com.ctrip.framework.apollo.openapi.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.ctrip.framework.apollo.openapi.client.extend.IdempotentHttpMethod;
 import com.ctrip.framework.apollo.openapi.dto.NamespaceReleaseDTO;
 import com.ctrip.framework.apollo.openapi.dto.OpenAppDTO;
 import com.ctrip.framework.apollo.openapi.dto.OpenAppNamespaceDTO;
@@ -63,6 +64,8 @@ class ApolloOpenApiClientIntegrationTest {
         .withToken(someToken)
         .withReadTimeout(2000 * 1000)
         .withConnectTimeout(2000 * 1000)
+        .withRetryCount(3)
+        .withIdempotentHttpMethods(IdempotentHttpMethod.safe())
         .build();
   }
 


### PR DESCRIPTION
## What's the purpose of this PR

about issue [104](https://github.com/apolloconfig/apollo-java/issues/104)

## Brief changelog

1.Custom HttpRequestRetyHandler supports all method requests to be retried
2.Add retry count parameter, default no retry

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [x] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable retry functionality to the open API client, allowing users to specify the number of retry attempts and define which HTTP methods are considered idempotent for retries.

- **Documentation**
  - Updated release notes to document the new retry support in the open API client.

- **Tests**
  - Enhanced integration tests to include configuration for the retry feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->