### PR TITLE
fix: ConfigService.getConfig(appId, namespace) returns wrong app's config

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/ConfigService.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/ConfigService.java
@@ -101,6 +101,19 @@ public class ConfigService {
     return s_instance.getManager().getConfigFile(namespace, configFileFormat);
   }
 
+  /**
+   * Get the config file instance for the appId and namespace.
+   *
+   * @param appId            the appId of the config
+   * @param namespace        the namespace of the config without file extension, e.g. "application"
+   * @param configFileFormat the config file format
+   * @return config file instance
+   */
+  public static ConfigFile getConfigFile(String appId, String namespace,
+      ConfigFileFormat configFileFormat) {
+    return s_instance.getManager().getConfigFile(appId, namespace, configFileFormat);
+  }
+
   public static ConfigMonitor getConfigMonitor(){
       return s_instance.getMonitor();
   }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigFactory.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigFactory.java
@@ -163,7 +163,7 @@ public class DefaultConfigFactory implements ConfigFactory {
       String appId, String namespace, ConfigFileFormat format) {
     String actualNamespaceName = trimNamespaceFormat(namespace, format);
     PropertiesCompatibleConfigFile configFile = (PropertiesCompatibleConfigFile) ConfigService
-        .getConfigFile(actualNamespaceName, format);
+        .getConfigFile(appId, actualNamespaceName, format);
 
     return new PropertiesCompatibleFileConfigRepository(configFile);
   }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/ConfigServiceTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/ConfigServiceTest.java
@@ -103,6 +103,34 @@ public class ConfigServiceTest {
     assertEquals(someNamespaceFileName + ":" + someConfigFileFormat.getValue(), configFile.getContent());
   }
 
+  @Test
+  public void testGetConfigWithCustomAppId() throws Exception {
+    String customAppId = "customAppId";
+    String someNamespace = "mock";
+    String someKey = "someKey";
+    MockInjector.setInstance(ConfigFactory.class, someNamespace, new MockConfigFactory());
+
+    Config config = ConfigService.getConfig(customAppId, someNamespace);
+
+    assertEquals(customAppId + ConfigConsts.CLUSTER_NAMESPACE_SEPARATOR + someNamespace + ":" + someKey,
+        config.getProperty(someKey, null));
+  }
+
+  @Test
+  public void testGetConfigFileWithCustomAppId() throws Exception {
+    String customAppId = "customAppId";
+    String someNamespace = "mock";
+    ConfigFileFormat someConfigFileFormat = ConfigFileFormat.YML;
+    String someNamespaceFileName =
+        String.format("%s.%s", someNamespace, someConfigFileFormat.getValue());
+    MockInjector.setInstance(ConfigFactory.class, someNamespaceFileName, new MockConfigFactory());
+
+    ConfigFile configFile = ConfigService.getConfigFile(customAppId, someNamespace, someConfigFileFormat);
+
+    assertEquals(customAppId, configFile.getAppId());
+    assertEquals(someNamespaceFileName, configFile.getNamespace());
+  }
+
   private static class MockConfig extends AbstractConfig {
     private final String m_appId;
     private final String m_namespace;

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/ConfigServiceTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/ConfigServiceTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertEquals;
 
 import com.ctrip.framework.apollo.core.MetaDomainConsts;
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
+import com.ctrip.framework.apollo.spi.DefaultConfigFactory;
+import java.util.Properties;
 import java.util.Set;
 
 import org.junit.After;
@@ -131,6 +133,32 @@ public class ConfigServiceTest {
     assertEquals(someNamespaceFileName, configFile.getNamespace());
   }
 
+  @Test
+  public void testGetConfigWithCustomAppIdForPropertiesCompatibleNamespace() throws Exception {
+    String customAppId = "customAppId";
+    String someNamespace = "mock";
+    ConfigFileFormat someConfigFileFormat = ConfigFileFormat.YML;
+    String someNamespaceFileName =
+        String.format("%s.%s", someNamespace, someConfigFileFormat.getValue());
+
+    // Exercise the real DefaultConfigFactory path for a non-properties namespace, i.e.
+    // create(appId, "mock.yml") -> createPropertiesCompatibleFileConfigRepository(...) ->
+    // ConfigService.getConfigFile(appId, "mock", YML). Only createConfigFile is stubbed (to avoid
+    // hitting a remote repository); it echoes the appId it receives into the resulting properties so
+    // the assertion below fails if DefaultConfigFactory ever drops the custom appId again.
+    MockInjector.setInstance(ConfigFactory.class, someNamespaceFileName, new DefaultConfigFactory() {
+      @Override
+      public ConfigFile createConfigFile(String appId, String namespace,
+          ConfigFileFormat configFileFormat) {
+        return new MockPropertiesCompatibleConfigFile(appId, namespace, configFileFormat);
+      }
+    });
+
+    Config config = ConfigService.getConfig(customAppId, someNamespaceFileName);
+
+    assertEquals(customAppId, config.getProperty("appId", null));
+  }
+
   private static class MockConfig extends AbstractConfig {
     private final String m_appId;
     private final String m_namespace;
@@ -238,6 +266,67 @@ public class ConfigServiceTest {
     @Override
     public ConfigFile createConfigFile(String appId, String namespace, ConfigFileFormat configFileFormat) {
       return new MockConfigFile(appId, namespace, configFileFormat);
+    }
+  }
+
+  private static class MockPropertiesCompatibleConfigFile implements PropertiesCompatibleConfigFile {
+    private final String m_appId;
+    private final String m_namespace;
+    private final ConfigFileFormat m_configFileFormat;
+
+    public MockPropertiesCompatibleConfigFile(String appId, String namespace,
+        ConfigFileFormat configFileFormat) {
+      m_appId = appId;
+      m_namespace = namespace;
+      m_configFileFormat = configFileFormat;
+    }
+
+    @Override
+    public Properties asProperties() {
+      Properties properties = new Properties();
+      // echo the appId so it is observable through the resulting Config
+      properties.setProperty("appId", m_appId);
+      return properties;
+    }
+
+    @Override
+    public String getContent() {
+      return null;
+    }
+
+    @Override
+    public boolean hasContent() {
+      return true;
+    }
+
+    @Override
+    public String getAppId() {
+      return m_appId;
+    }
+
+    @Override
+    public String getNamespace() {
+      return m_namespace;
+    }
+
+    @Override
+    public ConfigFileFormat getConfigFileFormat() {
+      return m_configFileFormat;
+    }
+
+    @Override
+    public void addChangeListener(ConfigFileChangeListener listener) {
+
+    }
+
+    @Override
+    public boolean removeChangeListener(ConfigFileChangeListener listener) {
+      return false;
+    }
+
+    @Override
+    public ConfigSourceType getSourceType() {
+      return ConfigSourceType.REMOTE;
     }
   }
 


### PR DESCRIPTION
## Problem

`ConfigService.getConfig(appId, "some-namespace.yml")` silently returns config belonging to the **default** application (`app.id` in `app.properties`) instead of the requested `appId`, with no error or warning.

The same bug affects any non-properties namespace format (YAML, YML, JSON, XML, TXT).

## Root cause

`DefaultConfigFactory.create(appId, namespace)` correctly dispatches to `createPropertiesCompatibleFileConfigRepository(appId, namespace, format)` for non-properties namespaces, but that method then calls the **two-arg** `ConfigService.getConfigFile(namespace, format)` — silently dropping `appId`:

```java
// DefaultConfigFactory.java (before fix)
PropertiesCompatibleFileConfigRepository createPropertiesCompatibleFileConfigRepository(
    String appId, String namespace, ConfigFileFormat format) {
  String actualNamespaceName = trimNamespaceFormat(namespace, format);
  PropertiesCompatibleConfigFile configFile = (PropertiesCompatibleConfigFile) ConfigService
      .getConfigFile(actualNamespaceName, format);   // ← appId silently dropped
  return new PropertiesCompatibleFileConfigRepository(configFile);
}
```

`ConfigManager` already had a correct three-arg `getConfigFile(appId, namespace, format)` overload, but it was not exposed on `ConfigService`.

## Fix

**`ConfigService.java`** — add the missing overload that mirrors the existing `getConfig(appId, namespace)` pattern:

```java
public static ConfigFile getConfigFile(String appId, String namespace,
    ConfigFileFormat configFileFormat) {
  return s_instance.getManager().getConfigFile(appId, namespace, configFileFormat);
}
```

**`DefaultConfigFactory.java`** — use the new overload so `appId` is preserved:

```java
configFile = (PropertiesCompatibleConfigFile) ConfigService
    .getConfigFile(appId, actualNamespaceName, format);   // ← appId preserved
```

## Tests

| Test | What it verifies |
|------|-----------------|| `ConfigServiceTest.testGetConfigWithCustomAppId` | `ConfigService.getConfig(appId, namespace)` returns a `Config` whose property values reflect the requested appId, not the default |
| `ConfigServiceTest.testGetConfigFileWithCustomAppId` | `ConfigService.getConfigFile(appId, ns, format)` returns a `ConfigFile` whose `getAppId()` matches the requested appId |

## Affected versions

Reproducible on `apollo-client 2.4.0` and `2.5.0`. `ConfigFileFormat.Properties` namespaces are unaffected (they go through `createConfigRepository`, not `createPropertiesCompatibleFileConfigRepository`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public overload to retrieve configuration files using a custom application ID, namespace, and an explicit format for finer-grained configuration access.

* **Tests**
  * Expanded test coverage to verify custom application IDs are correctly propagated for both configuration retrieval and configuration-file retrieval, including behavior when resolving properties-compatible namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->