### PR TITLE
test: fix flaky SpringAnnotationCompatibilityTest.shouldSupportAnnotationAndMultipleConfig

### DIFF
--- a/apollo-compat-tests/apollo-spring-compat-it/src/test/java/com/ctrip/framework/apollo/compat/spring/SpringAnnotationCompatibilityTest.java
+++ b/apollo-compat-tests/apollo-spring-compat-it/src/test/java/com/ctrip/framework/apollo/compat/spring/SpringAnnotationCompatibilityTest.java
@@ -122,8 +122,13 @@ public class SpringAnnotationCompatibilityTest {
     assertNotNull(anotherAppChange);
     assertNotNull(anotherAppChange.getChange("compat.origin"));
 
-    String namespace = apolloEventListenerProbe.pollNamespace(10, TimeUnit.SECONDS);
-    assertEquals("application", namespace);
+    // config change listeners are notified asynchronously, so events from different
+    // namespaces may arrive in any order
+    SpringCompatibilityTestSupport.waitForCondition(
+        "ApplicationListener should receive namespace updates",
+        () -> apolloEventListenerProbe.hasNamespace("application")
+            && apolloEventListenerProbe.hasNamespace("TEST1.apollo")
+            && apolloEventListenerProbe.hasNamespace("application.yaml"));
 
     SpringCompatibilityTestSupport.waitForCondition("public value should be updated",
         () -> "from-public-updated".equals(

--- a/apollo-compat-tests/apollo-spring-compat-it/src/test/java/com/ctrip/framework/apollo/compat/spring/SpringApolloEventListenerProbe.java
+++ b/apollo-compat-tests/apollo-spring-compat-it/src/test/java/com/ctrip/framework/apollo/compat/spring/SpringApolloEventListenerProbe.java
@@ -17,24 +17,24 @@
 package com.ctrip.framework.apollo.compat.spring;
 
 import com.ctrip.framework.apollo.spring.events.ApolloConfigChangeEvent;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 
 public class SpringApolloEventListenerProbe implements ApplicationListener {
 
-  private final BlockingQueue<String> namespaces = new LinkedBlockingQueue<String>();
+  private final Set<String> namespaces = Collections.synchronizedSet(new HashSet<String>());
 
   @Override
   public void onApplicationEvent(ApplicationEvent event) {
     if (event instanceof ApolloConfigChangeEvent) {
-      namespaces.offer(((ApolloConfigChangeEvent) event).getConfigChangeEvent().getNamespace());
+      namespaces.add(((ApolloConfigChangeEvent) event).getConfigChangeEvent().getNamespace());
     }
   }
 
-  public String pollNamespace(long timeout, TimeUnit unit) throws InterruptedException {
-    return namespaces.poll(timeout, unit);
+  public boolean hasNamespace(String namespace) {
+    return namespaces.contains(namespace);
   }
 }


### PR DESCRIPTION
## What

Fixes a flaky test that sometimes fails CI with:

```
SpringAnnotationCompatibilityTest.shouldSupportAnnotationAndMultipleConfig:126 expected:<application[]> but was:<application[.yaml]>
```

Failed runs:
- https://github.com/apolloconfig/apollo-java/actions/runs/27198892381/job/80297531989
- https://github.com/apolloconfig/apollo-java/actions/runs/24199141594/job/70637581925

## Why it was flaky

The test changes config for several namespaces. Each change sends a Spring event, and all events go into one shared queue. The test then checks that the **first** event in the queue is for namespace `application`.

But Apollo sends these events on background threads (`AbstractConfig#notifyAsync` uses a thread pool), so the order they arrive is random. Most of the time `application` arrives first and the test passes. Sometimes `application.yaml` wins the race and the test fails.

I confirmed this by logging the events: even when the `application.yaml` change was fired first, the `application` event could still arrive first — the order depends only on thread scheduling.

## Fix

Stop checking the order. Instead, wait until all expected namespaces (`application`, `TEST1.apollo`, `application.yaml`) have been seen, in any order. This is the same approach already used in `ApolloSpringBootCompatibilityTest`.

## Testing

- Ran the fixed suite 15 times with Spring 3.1.1 + JDK 8 (the failing CI matrix) — all passed
- Ran 5 times with the event order deliberately reversed — all passed
- Ran once with Spring 6.1.18 + JDK 17 — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Spring compatibility tests now accept namespace update events arriving in any order across multiple configurations.
  * Test probe updated to track seen namespaces and provide non-blocking checks for namespace arrival, removing reliance on blocking/polling semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->