### PR TITLE
feat: support extendInfo in OpenAPI getNamespace(s) calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Apollo Java 2.6.0
 ------------------
 
 * [Fix Apollo client local cache fallback for Spring Boot 3 executable JARs](https://github.com/apolloconfig/apollo-java/pull/136)
+* [Support `extendInfo`/`parentAppId` in OpenAPI `getNamespace(s)` client calls](https://github.com/apolloconfig/apollo-java/pull/144)
 
 ------------------
 All issues and pull requests are [here](https://github.com/apolloconfig/apollo-java/milestone/6?closed=1)

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/NamespaceOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/api/NamespaceOpenApiService.java
@@ -36,6 +36,20 @@ public interface NamespaceOpenApiService {
    */
   OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName, boolean fillItemDetail);
 
+  /**
+   * Retrieves a single namespace, optionally including extra info such as {@code parentAppId}
+   * of an associated public namespace.
+   * <p>
+   * Default implementation falls back to {@link #getNamespace(String, String, String, String, boolean)}
+   * and ignores {@code extendInfo}, for backward compatibility with implementations written
+   * before this method was introduced. Implementations that support extendInfo should override
+   * this method directly.
+   * @since 2.6.0
+   */
+  default OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName, boolean fillItemDetail, boolean extendInfo) {
+    return getNamespace(appId, env, clusterName, namespaceName, fillItemDetail);
+  }
+
   default List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName) {
     return getNamespaces(appId, env, clusterName, true);
   }
@@ -45,6 +59,20 @@ public interface NamespaceOpenApiService {
    * @since 2.4.0
    */
   List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName, boolean fillItemDetail);
+
+  /**
+   * Retrieves a list namespaces, optionally including extra info such as {@code parentAppId}
+   * of an associated public namespace.
+   * <p>
+   * Default implementation falls back to {@link #getNamespaces(String, String, String, boolean)}
+   * and ignores {@code extendInfo}, for backward compatibility with implementations written
+   * before this method was introduced. Implementations that support extendInfo should override
+   * this method directly.
+   * @since 2.6.0
+   */
+  default List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName, boolean fillItemDetail, boolean extendInfo) {
+    return getNamespaces(appId, env, clusterName, fillItemDetail);
+  }
 
   OpenAppNamespaceDTO createAppNamespace(OpenAppNamespaceDTO appNamespaceDTO);
 

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiClient.java
@@ -129,6 +129,15 @@ public class ApolloOpenApiClient {
     return namespaceService.getNamespaces(appId, env, clusterName, fillItemDetail);
   }
 
+
+  /**
+   * Get the namespaces with extendInfo
+   * @since 2.6.0
+   */
+  public List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName, boolean fillItemDetail,  boolean extendInfo) {
+    return namespaceService.getNamespaces(appId, env, clusterName, fillItemDetail, extendInfo);
+  }
+
   /**
    * Get the cluster
    *
@@ -157,6 +166,14 @@ public class ApolloOpenApiClient {
    */
   public OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName, boolean fillItemDetail) {
     return namespaceService.getNamespace(appId, env, clusterName, namespaceName, fillItemDetail);
+  }
+
+  /**
+   * Get the namespace with extendInfo
+   * @since 2.6.0
+   */
+  public OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName, boolean fillItemDetail,  boolean extendInfo) {
+    return namespaceService.getNamespace(appId, env, clusterName, namespaceName, fillItemDetail, extendInfo);
   }
 
   /**

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiService.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiService.java
@@ -42,6 +42,11 @@ public class NamespaceOpenApiService extends AbstractOpenApiService implements
 
   @Override
   public OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName, boolean fillItemDetail) {
+    return getNamespace(appId, env, clusterName, namespaceName, fillItemDetail, false);
+  }
+
+  @Override
+  public OpenNamespaceDTO getNamespace(String appId, String env, String clusterName, String namespaceName, boolean fillItemDetail, boolean extendInfo) {
     if (Strings.isNullOrEmpty(clusterName)) {
       clusterName = ConfigConsts.CLUSTER_NAME_DEFAULT;
     }
@@ -59,6 +64,7 @@ public class NamespaceOpenApiService extends AbstractOpenApiService implements
         .namespacesPathVal(namespaceName);
 
     pathBuilder.addParam("fillItemDetail", fillItemDetail);
+    pathBuilder.addParam("extendInfo", extendInfo);
 
     try (CloseableHttpResponse response = get(pathBuilder)) {
       return gson.fromJson(EntityUtils.toString(response.getEntity()), OpenNamespaceDTO.class);
@@ -71,6 +77,11 @@ public class NamespaceOpenApiService extends AbstractOpenApiService implements
 
   @Override
   public List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName, boolean fillItemDetail) {
+    return getNamespaces(appId, env, clusterName, fillItemDetail, false);
+  }
+
+  @Override
+  public List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName, boolean fillItemDetail, boolean extendInfo) {
     if (Strings.isNullOrEmpty(clusterName)) {
       clusterName = ConfigConsts.CLUSTER_NAME_DEFAULT;
     }
@@ -85,6 +96,7 @@ public class NamespaceOpenApiService extends AbstractOpenApiService implements
         .customResource("namespaces");
 
     pathBuilder.addParam("fillItemDetail", fillItemDetail);
+    pathBuilder.addParam("extendInfo", extendInfo);
 
     try (CloseableHttpResponse response = get(pathBuilder)) {
       return gson.fromJson(EntityUtils.toString(response.getEntity()), OPEN_NAMESPACE_DTO_LIST_TYPE);

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/dto/OpenNamespaceDTO.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/dto/OpenNamespaceDTO.java
@@ -34,6 +34,8 @@ public class OpenNamespaceDTO extends BaseDTO {
 
   private List<OpenItemDTO> items;
 
+  private OpenNamespaceExtendDTO extendInfo;
+
   public String getAppId() {
     return appId;
   }
@@ -90,6 +92,14 @@ public class OpenNamespaceDTO extends BaseDTO {
     this.items = items;
   }
 
+  public OpenNamespaceExtendDTO getExtendInfo() {
+    return extendInfo;
+  }
+
+  public void setExtendInfo(OpenNamespaceExtendDTO extendInfo) {
+    this.extendInfo = extendInfo;
+  }
+
   @Override
   public String toString() {
     return "OpenNamespaceDTO{" +
@@ -100,6 +110,7 @@ public class OpenNamespaceDTO extends BaseDTO {
         ", format='" + format + '\'' +
         ", isPublic=" + isPublic +
         ", items=" + items +
+        ", extendInfo=" + extendInfo +
         ", dataChangeCreatedBy='" + dataChangeCreatedBy + '\'' +
         ", dataChangeLastModifiedBy='" + dataChangeLastModifiedBy + '\'' +
         ", dataChangeCreatedTime=" + dataChangeCreatedTime +

--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/dto/OpenNamespaceExtendDTO.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/dto/OpenNamespaceExtendDTO.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.dto;
+
+/**
+ * Extra namespace info only returned when requesting with {@code extendInfo=true}.
+ *
+ * @since 2.6.0
+ */
+public class OpenNamespaceExtendDTO {
+
+  private Boolean isConfigHidden;
+
+  private String parentAppId;
+
+  private Integer itemModifiedCnt;
+
+  public Boolean getIsConfigHidden() {
+    return isConfigHidden;
+  }
+
+  public void setIsConfigHidden(Boolean isConfigHidden) {
+    this.isConfigHidden = isConfigHidden;
+  }
+
+  public String getParentAppId() {
+    return parentAppId;
+  }
+
+  public void setParentAppId(String parentAppId) {
+    this.parentAppId = parentAppId;
+  }
+
+  public Integer getItemModifiedCnt() {
+    return itemModifiedCnt;
+  }
+
+  public void setItemModifiedCnt(Integer itemModifiedCnt) {
+    this.itemModifiedCnt = itemModifiedCnt;
+  }
+
+  @Override
+  public String toString() {
+    return "OpenNamespaceExtendDTO{" +
+        "isConfigHidden=" + isConfigHidden +
+        ", parentAppId='" + parentAppId + '\'' +
+        ", itemModifiedCnt=" + itemModifiedCnt +
+        '}';
+  }
+}

--- a/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/api/NamespaceOpenApiServiceTest.java
+++ b/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/api/NamespaceOpenApiServiceTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import com.ctrip.framework.apollo.openapi.dto.OpenAppNamespaceDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenNamespaceDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenNamespaceLockDTO;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Regression tests for the {@code extendInfo} default compatibility bridges added in 2.6.0.
+ * <p>
+ * {@link LegacyNamespaceOpenApiService} below only implements the pre-2.6.0 abstract contract
+ * (the {@code fillItemDetail} overloads), exactly like an external implementation or test double
+ * written before {@code extendInfo} was introduced. The fact that it compiles at all is itself
+ * part of the regression being guarded against.
+ */
+public class NamespaceOpenApiServiceTest {
+
+  @Test
+  public void testGetNamespaceDefaultBridgeDelegatesToLegacyMethod() {
+    LegacyNamespaceOpenApiService legacyService = new LegacyNamespaceOpenApiService();
+
+    OpenNamespaceDTO result = legacyService.getNamespace("someAppId", "someEnv", "someCluster",
+        "someNamespace", true, true);
+
+    assertSame(legacyService.lastNamespaceResult, result);
+    assertEquals(true, legacyService.lastFillItemDetail);
+  }
+
+  @Test
+  public void testGetNamespacesDefaultBridgeDelegatesToLegacyMethod() {
+    LegacyNamespaceOpenApiService legacyService = new LegacyNamespaceOpenApiService();
+
+    List<OpenNamespaceDTO> result = legacyService.getNamespaces("someAppId", "someEnv",
+        "someCluster", false, true);
+
+    assertSame(legacyService.lastNamespacesResult, result);
+    assertEquals(false, legacyService.lastFillItemDetail);
+  }
+
+  /**
+   * A minimal stand-in for an implementation written before the {@code extendInfo} overloads
+   * existed: it only overrides the {@code fillItemDetail} methods that were abstract prior to
+   * 2.6.0, and never touches {@code extendInfo} at all.
+   */
+  private static class LegacyNamespaceOpenApiService implements NamespaceOpenApiService {
+
+    private final OpenNamespaceDTO lastNamespaceResult = new OpenNamespaceDTO();
+    private final List<OpenNamespaceDTO> lastNamespacesResult = Collections.emptyList();
+    private boolean lastFillItemDetail;
+
+    @Override
+    public OpenNamespaceDTO getNamespace(String appId, String env, String clusterName,
+        String namespaceName, boolean fillItemDetail) {
+      this.lastFillItemDetail = fillItemDetail;
+      return lastNamespaceResult;
+    }
+
+    @Override
+    public List<OpenNamespaceDTO> getNamespaces(String appId, String env, String clusterName,
+        boolean fillItemDetail) {
+      this.lastFillItemDetail = fillItemDetail;
+      return lastNamespacesResult;
+    }
+
+    @Override
+    public OpenAppNamespaceDTO createAppNamespace(OpenAppNamespaceDTO appNamespaceDTO) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OpenNamespaceLockDTO getNamespaceLock(String appId, String env, String clusterName,
+        String namespaceName) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiMockIntegrationTest.java
+++ b/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/ApolloOpenApiMockIntegrationTest.java
@@ -129,8 +129,47 @@ public class ApolloOpenApiMockIntegrationTest {
     assertEquals("GET", request.method);
     assertEquals("/openapi/v1/envs/DEV/apps/SampleApp/clusters/default/namespaces/application",
         request.path);
-    assertEquals("fillItemDetail=true", request.query);
+    assertEquals("fillItemDetail=true&extendInfo=false", request.query);
     assertEquals("namespace-token", request.authorization);
+  }
+
+  @Test
+  public void shouldPassExtendInfoFlagAndParseItForGetNamespace() throws Exception {
+    handler.mock("GET", "/openapi/v1/envs/DEV/apps/SampleApp/clusters/default/namespaces/application",
+        200,
+        "{\"appId\":\"SampleApp\",\"clusterName\":\"default\",\"namespaceName\":\"application\","
+            + "\"extendInfo\":{\"parentAppId\":\"public-app\",\"isConfigHidden\":true,\"itemModifiedCnt\":3}}");
+    ApolloOpenApiClient client = newClient("namespace-extend-token");
+
+    OpenNamespaceDTO namespaceDTO = client
+        .getNamespace("SampleApp", "DEV", null, null, true, true);
+    CapturedRequest request = handler.awaitRequest(5, TimeUnit.SECONDS);
+
+    assertEquals("fillItemDetail=true&extendInfo=true", request.query);
+    assertNotNull(namespaceDTO.getExtendInfo());
+    assertEquals("public-app", namespaceDTO.getExtendInfo().getParentAppId());
+    assertEquals(Boolean.TRUE, namespaceDTO.getExtendInfo().getIsConfigHidden());
+    assertEquals(3, namespaceDTO.getExtendInfo().getItemModifiedCnt().intValue());
+  }
+
+  @Test
+  public void shouldPassExtendInfoFlagAndParseItForGetNamespaces() throws Exception {
+    handler.mock("GET", "/openapi/v1/envs/DEV/apps/SampleApp/clusters/default/namespaces",
+        200,
+        "[{\"appId\":\"SampleApp\",\"clusterName\":\"default\",\"namespaceName\":\"application\","
+            + "\"extendInfo\":{\"parentAppId\":\"public-app\",\"isConfigHidden\":false,\"itemModifiedCnt\":1}}]");
+    ApolloOpenApiClient client = newClient("namespaces-extend-token");
+
+    List<OpenNamespaceDTO> namespaceDTOs = client
+        .getNamespaces("SampleApp", "DEV", "default", true, true);
+    CapturedRequest request = handler.awaitRequest(5, TimeUnit.SECONDS);
+
+    assertEquals("fillItemDetail=true&extendInfo=true", request.query);
+    assertEquals(1, namespaceDTOs.size());
+    assertNotNull(namespaceDTOs.get(0).getExtendInfo());
+    assertEquals("public-app", namespaceDTOs.get(0).getExtendInfo().getParentAppId());
+    assertEquals(Boolean.FALSE, namespaceDTOs.get(0).getExtendInfo().getIsConfigHidden());
+    assertEquals(1, namespaceDTOs.get(0).getExtendInfo().getItemModifiedCnt().intValue());
   }
 
   @Test

--- a/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiServiceTest.java
+++ b/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/NamespaceOpenApiServiceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.ctrip.framework.apollo.openapi.dto.OpenAppNamespaceDTO;
+import com.ctrip.framework.apollo.openapi.dto.OpenNamespaceDTO;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -38,6 +39,7 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
   private String someCluster;
   private String someNamespace;
   private boolean fillItemDetail;
+  private boolean extendInfo;
 
   @Override
   @Before
@@ -77,9 +79,49 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
 
     HttpGet get = request.getValue();
 
-    assertEquals(String.format("%s/envs/%s/apps/%s/clusters/%s/namespaces/%s?fillItemDetail=%s",
+    assertEquals(String.format("%s/envs/%s/apps/%s/clusters/%s/namespaces/%s?fillItemDetail=%s&extendInfo=false",
                                someBaseUrl, someEnv, someAppId, someCluster, someNamespace, fillItemDetail),
                  get.getURI().toString());
+  }
+
+  @Test
+  public void testGetNamespaceWithExtendInfoTrue() throws Exception {
+    verifyGetNamespaceWithExtendInfo(true);
+  }
+
+  @Test
+  public void testGetNamespaceWithExtendInfoFalse() throws Exception {
+    verifyGetNamespaceWithExtendInfo(false);
+  }
+
+  private void verifyGetNamespaceWithExtendInfo(boolean extendInfoValue) throws Exception {
+    extendInfo = extendInfoValue;
+
+    final ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
+
+    namespaceOpenApiService.getNamespace(someAppId, someEnv, someCluster, someNamespace, fillItemDetail, extendInfo);
+
+    verify(httpClient, times(1)).execute(request.capture());
+
+    HttpGet get = request.getValue();
+
+    assertEquals(String.format("%s/envs/%s/apps/%s/clusters/%s/namespaces/%s?fillItemDetail=%s&extendInfo=%s",
+                               someBaseUrl, someEnv, someAppId, someCluster, someNamespace, fillItemDetail, extendInfo),
+                 get.getURI().toString());
+  }
+
+  @Test
+  public void testGetNamespaceDeserializesExtendInfo() throws Exception {
+    StringEntity responseEntity = new StringEntity(
+        "{\"appId\":\"someAppId\",\"extendInfo\":{\"parentAppId\":\"public-app\",\"isConfigHidden\":false,\"itemModifiedCnt\":2}}");
+    when(someHttpResponse.getEntity()).thenReturn(responseEntity);
+
+    OpenNamespaceDTO result = namespaceOpenApiService
+        .getNamespace(someAppId, someEnv, someCluster, someNamespace, true, true);
+
+    assertEquals("public-app", result.getExtendInfo().getParentAppId());
+    assertEquals(false, result.getExtendInfo().getIsConfigHidden());
+    assertEquals(2, result.getExtendInfo().getItemModifiedCnt().intValue());
   }
 
   @Test(expected = RuntimeException.class)
@@ -98,12 +140,12 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
 
   @Test
   public void testGetNamespaces() throws Exception {
-    verifyGetNamespace(true);
+    verifyGetNamespaces(true);
   }
 
   @Test
   public void testGetNamespacesWithFillItemDetailFalse() throws Exception {
-    verifyGetNamespace(false);
+    verifyGetNamespaces(false);
   }
 
 
@@ -122,7 +164,7 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
     HttpGet get = request.getValue();
 
     assertEquals(String
-                     .format("%s/envs/%s/apps/%s/clusters/%s/namespaces?fillItemDetail=%s", someBaseUrl, someEnv, someAppId, someCluster, fillItemDetail),
+                     .format("%s/envs/%s/apps/%s/clusters/%s/namespaces?fillItemDetail=%s&extendInfo=false", someBaseUrl, someEnv, someAppId, someCluster, fillItemDetail),
                  get.getURI().toString());
   }
 
@@ -131,6 +173,35 @@ public class NamespaceOpenApiServiceTest extends AbstractOpenApiServiceTest {
     when(statusLine.getStatusCode()).thenReturn(404);
 
     namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster, true);
+  }
+
+  @Test
+  public void testGetNamespacesWithExtendInfoTrue() throws Exception {
+    verifyGetNamespacesWithExtendInfo(true);
+  }
+
+  @Test
+  public void testGetNamespacesWithExtendInfoFalse() throws Exception {
+    verifyGetNamespacesWithExtendInfo(false);
+  }
+
+  private void verifyGetNamespacesWithExtendInfo(boolean extendInfoValue) throws Exception {
+    extendInfo = extendInfoValue;
+
+    StringEntity responseEntity = new StringEntity("[]");
+    when(someHttpResponse.getEntity()).thenReturn(responseEntity);
+
+    final ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
+
+    namespaceOpenApiService.getNamespaces(someAppId, someEnv, someCluster, fillItemDetail, extendInfo);
+
+    verify(httpClient, times(1)).execute(request.capture());
+
+    HttpGet get = request.getValue();
+
+    assertEquals(String.format("%s/envs/%s/apps/%s/clusters/%s/namespaces?fillItemDetail=%s&extendInfo=%s",
+                               someBaseUrl, someEnv, someAppId, someCluster, fillItemDetail, extendInfo),
+                 get.getURI().toString());
   }
 
   @Test(expected = RuntimeException.class)

--- a/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/dto/OpenNamespaceDTOTest.java
+++ b/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/dto/OpenNamespaceDTOTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.dto;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import org.junit.Test;
+
+public class OpenNamespaceDTOTest {
+
+  @Test
+  public void testGettersAndSetters() {
+    OpenNamespaceDTO dto = new OpenNamespaceDTO();
+    List<OpenItemDTO> items = Collections.singletonList(new OpenItemDTO());
+    OpenNamespaceExtendDTO extendInfo = new OpenNamespaceExtendDTO();
+
+    dto.setAppId("someAppId");
+    dto.setClusterName("someCluster");
+    dto.setNamespaceName("someNamespace");
+    dto.setComment("someComment");
+    dto.setFormat("properties");
+    dto.setPublic(true);
+    dto.setItems(items);
+    dto.setExtendInfo(extendInfo);
+
+    assertEquals("someAppId", dto.getAppId());
+    assertEquals("someCluster", dto.getClusterName());
+    assertEquals("someNamespace", dto.getNamespaceName());
+    assertEquals("someComment", dto.getComment());
+    assertEquals("properties", dto.getFormat());
+    assertTrue(dto.isPublic());
+    assertEquals(items, dto.getItems());
+    assertEquals(extendInfo, dto.getExtendInfo());
+  }
+
+  @Test
+  public void testDefaultValuesAreNull() {
+    OpenNamespaceDTO dto = new OpenNamespaceDTO();
+
+    assertNull(dto.getAppId());
+    assertNull(dto.getItems());
+    assertNull(dto.getExtendInfo());
+    assertEquals(false, dto.isPublic());
+  }
+
+  @Test
+  public void testInheritedBaseDTOFields() {
+    OpenNamespaceDTO dto = new OpenNamespaceDTO();
+    Date now = new Date();
+
+    dto.setDataChangeCreatedBy("someCreator");
+    dto.setDataChangeLastModifiedBy("someModifier");
+    dto.setDataChangeCreatedTime(now);
+    dto.setDataChangeLastModifiedTime(now);
+
+    assertEquals("someCreator", dto.getDataChangeCreatedBy());
+    assertEquals("someModifier", dto.getDataChangeLastModifiedBy());
+    assertEquals(now, dto.getDataChangeCreatedTime());
+    assertEquals(now, dto.getDataChangeLastModifiedTime());
+  }
+
+  @Test
+  public void testToStringContainsExtendInfo() {
+    OpenNamespaceDTO dto = new OpenNamespaceDTO();
+    dto.setAppId("someAppId");
+    OpenNamespaceExtendDTO extendInfo = new OpenNamespaceExtendDTO();
+    extendInfo.setParentAppId("public-app");
+    dto.setExtendInfo(extendInfo);
+
+    String result = dto.toString();
+
+    assertTrue(result.contains("someAppId"));
+    assertTrue(result.contains("public-app"));
+  }
+}

--- a/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/dto/OpenNamespaceExtendDTOTest.java
+++ b/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/dto/OpenNamespaceExtendDTOTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Apollo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ctrip.framework.apollo.openapi.dto;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class OpenNamespaceExtendDTOTest {
+
+  @Test
+  public void testGettersAndSetters() {
+    OpenNamespaceExtendDTO dto = new OpenNamespaceExtendDTO();
+
+    dto.setParentAppId("public-app");
+    dto.setIsConfigHidden(true);
+    dto.setItemModifiedCnt(5);
+
+    assertEquals("public-app", dto.getParentAppId());
+    assertEquals(Boolean.TRUE, dto.getIsConfigHidden());
+    assertEquals(5, dto.getItemModifiedCnt().intValue());
+  }
+
+  @Test
+  public void testDefaultValuesAreNull() {
+    OpenNamespaceExtendDTO dto = new OpenNamespaceExtendDTO();
+
+    assertNull(dto.getParentAppId());
+    assertNull(dto.getIsConfigHidden());
+    assertNull(dto.getItemModifiedCnt());
+  }
+
+  @Test
+  public void testToStringContainsAllFields() {
+    OpenNamespaceExtendDTO dto = new OpenNamespaceExtendDTO();
+    dto.setParentAppId("public-app");
+    dto.setIsConfigHidden(false);
+    dto.setItemModifiedCnt(2);
+
+    String result = dto.toString();
+
+    assertTrue(result.contains("public-app"));
+    assertTrue(result.contains("isConfigHidden=false"));
+    assertTrue(result.contains("itemModifiedCnt=2"));
+  }
+}


### PR DESCRIPTION
Add an `extendInfo` flag to the OpenAPI namespace retrieval endpoints so callers can opt into extra namespace metadata (e.g. parentAppId of an associated public namespace). Adds overloaded getNamespace/getNamespaces methods defaulting to the previous behavior, plus OpenNamespaceExtendDTO to carry the extra fields.

## What's the purpose of this PR

add extendInfo in openpai 

## Which issue(s) this PR fixes:
Fixes # https://github.com/apolloconfig/apollo/issues/5664

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Namespace retrieval APIs now support an optional `extendInfo` flag for single and multiple namespace requests.
  * Responses can include additional namespace metadata, including parent application ID, configuration visibility, and item modification count.
  * Existing calls retain their previous behavior by default.

* **Documentation**
  * Release notes now document `extendInfo` and `parentAppId` support in Apollo Java 2.6.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->