### PR TITLE
refactor: rename C++-style m_/s_ field prefixes to Java camelCase

### DIFF
--- a/apollo-client-config-data/src/test/java/com/ctrip/framework/apollo/config/data/importer/ApolloConfigDataLoaderTest.java
+++ b/apollo-client-config-data/src/test/java/com/ctrip/framework/apollo/config/data/importer/ApolloConfigDataLoaderTest.java
@@ -176,12 +176,12 @@ public class ApolloConfigDataLoaderTest {
   }
 
   private void clearApolloClientCaches() throws Exception {
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configs");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configLocks");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFiles");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFileLocks");
-    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "m_factories");
-    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "m_instances");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configs");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configLocks");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFiles");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFileLocks");
+    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "factories");
+    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "instances");
   }
 
   @SuppressWarnings("unchecked")

--- a/apollo-client-config-data/src/test/java/com/ctrip/framework/apollo/config/data/integration/ConfigDataIntegrationTest.java
+++ b/apollo-client-config-data/src/test/java/com/ctrip/framework/apollo/config/data/integration/ConfigDataIntegrationTest.java
@@ -255,12 +255,12 @@ public class ConfigDataIntegrationTest {
   }
 
   private static void clearApolloClientCaches() throws Exception {
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configs");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configLocks");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFiles");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFileLocks");
-    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "m_factories");
-    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "m_instances");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configs");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configLocks");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFiles");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFileLocks");
+    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "factories");
+    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "instances");
   }
 
   @SuppressWarnings("unchecked")

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/ConfigService.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/ConfigService.java
@@ -33,45 +33,45 @@ import com.ctrip.framework.apollo.util.ConfigUtil;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class ConfigService {
-  private static final ConfigService s_instance = new ConfigService();
-  private volatile ConfigMonitor m_configMonitor;
-  private volatile ConfigManager m_configManager;
-  private volatile ConfigRegistry m_configRegistry;
+  private static final ConfigService instance = new ConfigService();
+  private volatile ConfigMonitor configMonitor;
+  private volatile ConfigManager configManager;
+  private volatile ConfigRegistry configRegistry;
   
   private ConfigMonitor getMonitor() {
       getManager();
-      if (m_configMonitor == null) {
+      if (configMonitor == null) {
             synchronized (this) {
-                if (m_configMonitor == null) {
-                  m_configMonitor = ApolloInjector.getInstance(ConfigMonitor.class);
+                if (configMonitor == null) {
+                  configMonitor = ApolloInjector.getInstance(ConfigMonitor.class);
                 }
             }
       }
-      return m_configMonitor;
+      return configMonitor;
   }
   
   private ConfigManager getManager() {
-    if (m_configManager == null) {
+    if (configManager == null) {
       synchronized (this) {
-        if (m_configManager == null) {
-          m_configManager = ApolloInjector.getInstance(ConfigManager.class);
+        if (configManager == null) {
+          configManager = ApolloInjector.getInstance(ConfigManager.class);
           ConfigMonitorInitializer.initialize();
         }
       }
     }
-    return m_configManager;
+    return configManager;
   }
 
   private ConfigRegistry getRegistry() {
-    if (m_configRegistry == null) {
+    if (configRegistry == null) {
       synchronized (this) {
-        if (m_configRegistry == null) {
-          m_configRegistry = ApolloInjector.getInstance(ConfigRegistry.class);
+        if (configRegistry == null) {
+          configRegistry = ApolloInjector.getInstance(ConfigRegistry.class);
         }
       }
     }
 
-    return m_configRegistry;
+    return configRegistry;
   }
 
   /**
@@ -90,15 +90,15 @@ public class ConfigService {
    * @return config instance
    */
   public static Config getConfig(String namespace) {
-    return s_instance.getManager().getConfig(namespace);
+    return instance.getManager().getConfig(namespace);
   }
 
   public static Config getConfig(String appId, String namespace) {
-    return s_instance.getManager().getConfig(appId, namespace);
+    return instance.getManager().getConfig(appId, namespace);
   }
 
   public static ConfigFile getConfigFile(String namespace, ConfigFileFormat configFileFormat) {
-    return s_instance.getManager().getConfigFile(namespace, configFileFormat);
+    return instance.getManager().getConfigFile(namespace, configFileFormat);
   }
 
   /**
@@ -111,11 +111,11 @@ public class ConfigService {
    */
   public static ConfigFile getConfigFile(String appId, String namespace,
       ConfigFileFormat configFileFormat) {
-    return s_instance.getManager().getConfigFile(appId, namespace, configFileFormat);
+    return instance.getManager().getConfigFile(appId, namespace, configFileFormat);
   }
 
   public static ConfigMonitor getConfigMonitor(){
-      return s_instance.getMonitor();
+      return instance.getMonitor();
   }
 
   static void setConfig(Config config) {
@@ -129,9 +129,9 @@ public class ConfigService {
    * @param config    the config instance
    */
   static void setConfig(String namespace, final Config config) {
-    s_instance.getRegistry().register(namespace, new ConfigFactory() {
+    instance.getRegistry().register(namespace, new ConfigFactory() {
 
-      private final ConfigUtil m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+      private final ConfigUtil configUtil = ApolloInjector.getInstance(ConfigUtil.class);
 
       @Override
       public Config create(String namespace) {
@@ -140,8 +140,8 @@ public class ConfigService {
 
       @Override
       public Config create(String appId, String namespace) {
-        if(!StringUtils.equals(appId, m_configUtil.getAppId())){
-          throw new IllegalArgumentException("Provided appId '" + appId + "' does not match the default appId '" + m_configUtil.getAppId() + "'");
+        if(!StringUtils.equals(appId, configUtil.getAppId())){
+          throw new IllegalArgumentException("Provided appId '" + appId + "' does not match the default appId '" + configUtil.getAppId() + "'");
         }
         return config;
       }
@@ -170,14 +170,14 @@ public class ConfigService {
    * @param factory   the factory instance
    */
   static void setConfigFactory(String namespace, ConfigFactory factory) {
-    s_instance.getRegistry().register(namespace, factory);
+    instance.getRegistry().register(namespace, factory);
   }
 
   // for test only
   static void reset() {
-    synchronized (s_instance) {
-      s_instance.m_configManager = null;
-      s_instance.m_configRegistry = null;
+    synchronized (instance) {
+      instance.configManager = null;
+      instance.configRegistry = null;
     }
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/build/ApolloInjector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/build/ApolloInjector.java
@@ -25,15 +25,15 @@ import com.ctrip.framework.foundation.internals.ServiceBootstrap;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class ApolloInjector {
-  private static volatile Injector s_injector;
+  private static volatile Injector injector;
   private static final Object lock = new Object();
 
   private static Injector getInjector() {
-    if (s_injector == null) {
+    if (injector == null) {
       synchronized (lock) {
-        if (s_injector == null) {
+        if (injector == null) {
           try {
-            s_injector = ServiceBootstrap.loadPrimary(Injector.class);
+            injector = ServiceBootstrap.loadPrimary(Injector.class);
           } catch (Throwable ex) {
             ApolloConfigException exception = new ApolloConfigException("Unable to initialize Apollo Injector!", ex);
             Tracer.logError(exception);
@@ -43,7 +43,7 @@ public class ApolloInjector {
       }
     }
 
-    return s_injector;
+    return injector;
   }
 
   public static <T> T getInstance(Class<T> clazz) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/exceptions/ApolloConfigStatusCodeException.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/exceptions/ApolloConfigStatusCodeException.java
@@ -20,19 +20,19 @@ package com.ctrip.framework.apollo.exceptions;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class ApolloConfigStatusCodeException extends RuntimeException{
-  private final int m_statusCode;
+  private final int statusCode;
 
   public ApolloConfigStatusCodeException(int statusCode, String message) {
     super(String.format("[status code: %d] %s", statusCode, message));
-    this.m_statusCode = statusCode;
+    this.statusCode = statusCode;
   }
 
   public ApolloConfigStatusCodeException(int statusCode, Throwable cause) {
     super(cause);
-    this.m_statusCode = statusCode;
+    this.statusCode = statusCode;
   }
 
   public int getStatusCode() {
-    return m_statusCode;
+    return statusCode;
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfig.java
@@ -53,38 +53,38 @@ import java.util.concurrent.atomic.AtomicLong;
 public abstract class AbstractConfig implements Config {
   private static final Logger logger = LoggerFactory.getLogger(AbstractConfig.class);
 
-  protected static final ExecutorService m_executorService;
+  protected static final ExecutorService executorService;
 
-  private final List<ConfigChangeListener> m_listeners = Lists.newCopyOnWriteArrayList();
-  private final Map<ConfigChangeListener, Set<String>> m_interestedKeys =
+  private final List<ConfigChangeListener> listeners = Lists.newCopyOnWriteArrayList();
+  private final Map<ConfigChangeListener, Set<String>> interestedKeys =
       Collections.synchronizedMap(new IdentityHashMap<>());
-  private final Map<ConfigChangeListener, Set<String>> m_interestedKeyPrefixes =
+  private final Map<ConfigChangeListener, Set<String>> interestedKeyPrefixes =
       Collections.synchronizedMap(new IdentityHashMap<>());
-  private final ConfigUtil m_configUtil;
-  private volatile Cache<String, Integer> m_integerCache;
-  private volatile Cache<String, Long> m_longCache;
-  private volatile Cache<String, Short> m_shortCache;
-  private volatile Cache<String, Float> m_floatCache;
-  private volatile Cache<String, Double> m_doubleCache;
-  private volatile Cache<String, Byte> m_byteCache;
-  private volatile Cache<String, Boolean> m_booleanCache;
-  private volatile Cache<String, Date> m_dateCache;
-  private volatile Cache<String, Long> m_durationCache;
-  private final Map<String, Cache<String, String[]>> m_arrayCache;
+  private final ConfigUtil configUtil;
+  private volatile Cache<String, Integer> integerCache;
+  private volatile Cache<String, Long> longCache;
+  private volatile Cache<String, Short> shortCache;
+  private volatile Cache<String, Float> floatCache;
+  private volatile Cache<String, Double> doubleCache;
+  private volatile Cache<String, Byte> byteCache;
+  private volatile Cache<String, Boolean> booleanCache;
+  private volatile Cache<String, Date> dateCache;
+  private volatile Cache<String, Long> durationCache;
+  private final Map<String, Cache<String, String[]>> arrayCache;
   private final List<Cache> allCaches;
-  private final AtomicLong m_configVersion; //indicate config version
+  private final AtomicLong configVersion; //indicate config version
 
   protected PropertiesFactory propertiesFactory;
 
   static {
-    m_executorService = Executors.newCachedThreadPool(ApolloThreadFactory
+    executorService = Executors.newCachedThreadPool(ApolloThreadFactory
         .create("Config", true));
   }
 
   public AbstractConfig() {
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
-    m_configVersion = new AtomicLong();
-    m_arrayCache = Maps.newConcurrentMap();
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    configVersion = new AtomicLong();
+    arrayCache = Maps.newConcurrentMap();
     allCaches = Lists.newArrayList();
     propertiesFactory = ApolloInjector.getInstance(PropertiesFactory.class);
   }
@@ -102,35 +102,35 @@ public abstract class AbstractConfig implements Config {
   @Override
   public void addChangeListener(ConfigChangeListener listener, Set<String> interestedKeys, Set<String> interestedKeyPrefixes) {
     if (!containsListenerInstance(listener)) {
-      m_listeners.add(listener);
+      listeners.add(listener);
       if (interestedKeys != null && !interestedKeys.isEmpty()) {
-        m_interestedKeys.put(listener, Sets.newHashSet(interestedKeys));
+        this.interestedKeys.put(listener, Sets.newHashSet(interestedKeys));
       }
       if (interestedKeyPrefixes != null && !interestedKeyPrefixes.isEmpty()) {
-        m_interestedKeyPrefixes.put(listener, Sets.newHashSet(interestedKeyPrefixes));
+        this.interestedKeyPrefixes.put(listener, Sets.newHashSet(interestedKeyPrefixes));
       }
     }
   }
 
   @Override
   public boolean removeChangeListener(ConfigChangeListener listener) {
-    m_interestedKeys.remove(listener);
-    m_interestedKeyPrefixes.remove(listener);
-    return m_listeners.removeIf(addedListener -> addedListener == listener);
+    interestedKeys.remove(listener);
+    interestedKeyPrefixes.remove(listener);
+    return listeners.removeIf(addedListener -> addedListener == listener);
   }
 
   @Override
   public Integer getIntProperty(String key, Integer defaultValue) {
     try {
-      if (m_integerCache == null) {
+      if (integerCache == null) {
         synchronized (this) {
-          if (m_integerCache == null) {
-            m_integerCache = newCache();
+          if (integerCache == null) {
+            integerCache = newCache();
           }
         }
       }
 
-      return getValueFromCache(key, Functions.TO_INT_FUNCTION, m_integerCache, defaultValue);
+      return getValueFromCache(key, Functions.TO_INT_FUNCTION, integerCache, defaultValue);
     } catch (Throwable ex) {
       Tracer.logError(new ApolloConfigException(
           String.format("getIntProperty for %s failed, return default value %d", key,
@@ -142,15 +142,15 @@ public abstract class AbstractConfig implements Config {
   @Override
   public Long getLongProperty(String key, Long defaultValue) {
     try {
-      if (m_longCache == null) {
+      if (longCache == null) {
         synchronized (this) {
-          if (m_longCache == null) {
-            m_longCache = newCache();
+          if (longCache == null) {
+            longCache = newCache();
           }
         }
       }
 
-      return getValueFromCache(key, Functions.TO_LONG_FUNCTION, m_longCache, defaultValue);
+      return getValueFromCache(key, Functions.TO_LONG_FUNCTION, longCache, defaultValue);
     } catch (Throwable ex) {
       Tracer.logError(new ApolloConfigException(
           String.format("getLongProperty for %s failed, return default value %d", key,
@@ -162,15 +162,15 @@ public abstract class AbstractConfig implements Config {
   @Override
   public Short getShortProperty(String key, Short defaultValue) {
     try {
-      if (m_shortCache == null) {
+      if (shortCache == null) {
         synchronized (this) {
-          if (m_shortCache == null) {
-            m_shortCache = newCache();
+          if (shortCache == null) {
+            shortCache = newCache();
           }
         }
       }
 
-      return getValueFromCache(key, Functions.TO_SHORT_FUNCTION, m_shortCache, defaultValue);
+      return getValueFromCache(key, Functions.TO_SHORT_FUNCTION, shortCache, defaultValue);
     } catch (Throwable ex) {
       Tracer.logError(new ApolloConfigException(
           String.format("getShortProperty for %s failed, return default value %d", key,
@@ -182,15 +182,15 @@ public abstract class AbstractConfig implements Config {
   @Override
   public Float getFloatProperty(String key, Float defaultValue) {
     try {
-      if (m_floatCache == null) {
+      if (floatCache == null) {
         synchronized (this) {
-          if (m_floatCache == null) {
-            m_floatCache = newCache();
+          if (floatCache == null) {
+            floatCache = newCache();
           }
         }
       }
 
-      return getValueFromCache(key, Functions.TO_FLOAT_FUNCTION, m_floatCache, defaultValue);
+      return getValueFromCache(key, Functions.TO_FLOAT_FUNCTION, floatCache, defaultValue);
     } catch (Throwable ex) {
       Tracer.logError(new ApolloConfigException(
           String.format("getFloatProperty for %s failed, return default value %f", key,
@@ -202,15 +202,15 @@ public abstract class AbstractConfig implements Config {
   @Override
   public Double getDoubleProperty(String key, Double defaultValue) {
     try {
-      if (m_doubleCache == null) {
+      if (doubleCache == null) {
         synchronized (this) {
-          if (m_doubleCache == null) {
-            m_doubleCache = newCache();
+          if (doubleCache == null) {
+            doubleCache = newCache();
           }
         }
       }
 
-      return getValueFromCache(key, Functions.TO_DOUBLE_FUNCTION, m_doubleCache, defaultValue);
+      return getValueFromCache(key, Functions.TO_DOUBLE_FUNCTION, doubleCache, defaultValue);
     } catch (Throwable ex) {
       Tracer.logError(new ApolloConfigException(
           String.format("getDoubleProperty for %s failed, return default value %f", key,
@@ -222,15 +222,15 @@ public abstract class AbstractConfig implements Config {
   @Override
   public Byte getByteProperty(String key, Byte defaultValue) {
     try {
-      if (m_byteCache == null) {
+      if (byteCache == null) {
         synchronized (this) {
-          if (m_byteCache == null) {
-            m_byteCache = newCache();
+          if (byteCache == null) {
+            byteCache = newCache();
           }
         }
       }
 
-      return getValueFromCache(key, Functions.TO_BYTE_FUNCTION, m_byteCache, defaultValue);
+      return getValueFromCache(key, Functions.TO_BYTE_FUNCTION, byteCache, defaultValue);
     } catch (Throwable ex) {
       Tracer.logError(new ApolloConfigException(
           String.format("getByteProperty for %s failed, return default value %d", key,
@@ -242,15 +242,15 @@ public abstract class AbstractConfig implements Config {
   @Override
   public Boolean getBooleanProperty(String key, Boolean defaultValue) {
     try {
-      if (m_booleanCache == null) {
+      if (booleanCache == null) {
         synchronized (this) {
-          if (m_booleanCache == null) {
-            m_booleanCache = newCache();
+          if (booleanCache == null) {
+            booleanCache = newCache();
           }
         }
       }
 
-      return getValueFromCache(key, Functions.TO_BOOLEAN_FUNCTION, m_booleanCache, defaultValue);
+      return getValueFromCache(key, Functions.TO_BOOLEAN_FUNCTION, booleanCache, defaultValue);
     } catch (Throwable ex) {
       Tracer.logError(new ApolloConfigException(
           String.format("getBooleanProperty for %s failed, return default value %b", key,
@@ -262,15 +262,15 @@ public abstract class AbstractConfig implements Config {
   @Override
   public String[] getArrayProperty(String key, final String delimiter, String[] defaultValue) {
     try {
-      if (!m_arrayCache.containsKey(delimiter)) {
+      if (!arrayCache.containsKey(delimiter)) {
         synchronized (this) {
-          if (!m_arrayCache.containsKey(delimiter)) {
-            m_arrayCache.put(delimiter, this.newCache());
+          if (!arrayCache.containsKey(delimiter)) {
+            arrayCache.put(delimiter, this.newCache());
           }
         }
       }
 
-      Cache<String, String[]> cache = m_arrayCache.get(delimiter);
+      Cache<String, String[]> cache = arrayCache.get(delimiter);
       String[] result = cache.getIfPresent(key);
 
       if (result != null) {
@@ -310,15 +310,15 @@ public abstract class AbstractConfig implements Config {
   @Override
   public Date getDateProperty(String key, Date defaultValue) {
     try {
-      if (m_dateCache == null) {
+      if (dateCache == null) {
         synchronized (this) {
-          if (m_dateCache == null) {
-            m_dateCache = newCache();
+          if (dateCache == null) {
+            dateCache = newCache();
           }
         }
       }
 
-      return getValueFromCache(key, Functions.TO_DATE_FUNCTION, m_dateCache, defaultValue);
+      return getValueFromCache(key, Functions.TO_DATE_FUNCTION, dateCache, defaultValue);
     } catch (Throwable ex) {
       Tracer.logError(new ApolloConfigException(
           String.format("getDateProperty for %s failed, return default value %s", key,
@@ -365,15 +365,15 @@ public abstract class AbstractConfig implements Config {
   @Override
   public long getDurationProperty(String key, long defaultValue) {
     try {
-      if (m_durationCache == null) {
+      if (durationCache == null) {
         synchronized (this) {
-          if (m_durationCache == null) {
-            m_durationCache = newCache();
+          if (durationCache == null) {
+            durationCache = newCache();
           }
         }
       }
 
-      return getValueFromCache(key, Functions.TO_DURATION_FUNCTION, m_durationCache, defaultValue);
+      return getValueFromCache(key, Functions.TO_DURATION_FUNCTION, durationCache, defaultValue);
     } catch (Throwable ex) {
       Tracer.logError(new ApolloConfigException(
           String.format("getDurationProperty for %s failed, return default value %d", key,
@@ -411,7 +411,7 @@ public abstract class AbstractConfig implements Config {
   }
 
   private <T> T getValueAndStoreToCache(String key, Function<String, T> parser, Cache<String, T> cache, T defaultValue) {
-    long currentConfigVersion = m_configVersion.get();
+    long currentConfigVersion = configVersion.get();
     String value = getProperty(key, null);
 
     if (value != null) {
@@ -419,7 +419,7 @@ public abstract class AbstractConfig implements Config {
 
       if (result != null) {
         synchronized (this) {
-          if (m_configVersion.get() == currentConfigVersion) {
+          if (configVersion.get() == currentConfigVersion) {
             cache.put(key, result);
           }
         }
@@ -432,8 +432,8 @@ public abstract class AbstractConfig implements Config {
 
   private <T> Cache<String, T> newCache() {
     Cache<String, T> cache = CacheBuilder.newBuilder()
-        .maximumSize(m_configUtil.getMaxConfigCacheSize())
-        .expireAfterAccess(m_configUtil.getConfigCacheExpireTime(), m_configUtil.getConfigCacheExpireTimeUnit())
+        .maximumSize(configUtil.getMaxConfigCacheSize())
+        .expireAfterAccess(configUtil.getConfigCacheExpireTime(), configUtil.getConfigCacheExpireTimeUnit())
         .build();
     allCaches.add(cache);
     return cache;
@@ -449,7 +449,7 @@ public abstract class AbstractConfig implements Config {
           c.invalidateAll();
         }
       }
-      m_configVersion.incrementAndGet();
+      configVersion.incrementAndGet();
     }
   }
 
@@ -484,7 +484,7 @@ public abstract class AbstractConfig implements Config {
 
   private List<ConfigChangeListener> findMatchedConfigChangeListeners(Set<String> changedKeys) {
     final List<ConfigChangeListener> configChangeListeners = new ArrayList<>();
-    for (ConfigChangeListener configChangeListener : this.m_listeners) {
+    for (ConfigChangeListener configChangeListener : this.listeners) {
       // check whether the listener is interested in this change event
       if (this.isConfigChangeListenerInterested(configChangeListener, changedKeys)) {
         configChangeListeners.add(configChangeListener);
@@ -494,7 +494,7 @@ public abstract class AbstractConfig implements Config {
   }
 
   private void notifyAsync(final ConfigChangeListener listener, final ConfigChangeEvent changeEvent) {
-    m_executorService.submit(new Runnable() {
+    executorService.submit(new Runnable() {
       @Override
       public void run() {
         String listenerName = listener.getClass().getName();
@@ -514,8 +514,8 @@ public abstract class AbstractConfig implements Config {
   }
 
   private boolean isConfigChangeListenerInterested(ConfigChangeListener configChangeListener, Set<String> changedKeys) {
-    Set<String> interestedKeys = m_interestedKeys.get(configChangeListener);
-    Set<String> interestedKeyPrefixes = m_interestedKeyPrefixes.get(configChangeListener);
+    Set<String> interestedKeys = this.interestedKeys.get(configChangeListener);
+    Set<String> interestedKeyPrefixes = this.interestedKeyPrefixes.get(configChangeListener);
 
     if ((interestedKeys == null || interestedKeys.isEmpty())
         && (interestedKeyPrefixes == null || interestedKeyPrefixes.isEmpty())) {
@@ -546,8 +546,8 @@ public abstract class AbstractConfig implements Config {
   private Set<String> resolveInterestedChangedKeys(ConfigChangeListener configChangeListener, Set<String> changedKeys) {
     Set<String> interestedChangedKeys = new HashSet<>();
 
-    if (this.m_interestedKeys.containsKey(configChangeListener)) {
-      Set<String> interestedKeys = this.m_interestedKeys.get(configChangeListener);
+    if (this.interestedKeys.containsKey(configChangeListener)) {
+      Set<String> interestedKeys = this.interestedKeys.get(configChangeListener);
       for (String interestedKey : interestedKeys) {
         if (changedKeys.contains(interestedKey)) {
           interestedChangedKeys.add(interestedKey);
@@ -555,8 +555,8 @@ public abstract class AbstractConfig implements Config {
       }
     }
 
-    if (this.m_interestedKeyPrefixes.containsKey(configChangeListener)) {
-      Set<String> interestedKeyPrefixes = this.m_interestedKeyPrefixes.get(configChangeListener);
+    if (this.interestedKeyPrefixes.containsKey(configChangeListener)) {
+      Set<String> interestedKeyPrefixes = this.interestedKeyPrefixes.get(configChangeListener);
       for (String interestedKeyPrefix : interestedKeyPrefixes) {
         for (String changedKey : changedKeys) {
           if (changedKey.startsWith(interestedKeyPrefix)) {
@@ -612,7 +612,7 @@ public abstract class AbstractConfig implements Config {
   }
 
   private boolean containsListenerInstance(ConfigChangeListener listener) {
-    for (ConfigChangeListener configChangeListener : m_listeners) {
+    for (ConfigChangeListener configChangeListener : listeners) {
       if (configChangeListener == listener) {
         return true;
       }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigFile.java
@@ -45,65 +45,65 @@ import com.google.common.collect.Lists;
  */
 public abstract class AbstractConfigFile implements ConfigFile, RepositoryChangeListener {
   private static final Logger logger = DeferredLoggerFactory.getLogger(AbstractConfigFile.class);
-  protected static ExecutorService m_executorService;
-  protected final ConfigRepository m_configRepository;
-  protected final String m_appId;
-  protected final String m_namespace;
-  protected final AtomicReference<Properties> m_configProperties;
-  private final List<ConfigFileChangeListener> m_listeners = Lists.newCopyOnWriteArrayList();
+  protected static ExecutorService executorService;
+  protected final ConfigRepository configRepository;
+  protected final String appId;
+  protected final String namespace;
+  protected final AtomicReference<Properties> configProperties;
+  private final List<ConfigFileChangeListener> listeners = Lists.newCopyOnWriteArrayList();
   protected final PropertiesFactory propertiesFactory;
 
-  private volatile ConfigSourceType m_sourceType = ConfigSourceType.NONE;
+  private volatile ConfigSourceType sourceType = ConfigSourceType.NONE;
 
   static {
-    m_executorService = Executors.newCachedThreadPool(ApolloThreadFactory
+    executorService = Executors.newCachedThreadPool(ApolloThreadFactory
         .create("ConfigFile", true));
   }
 
   public AbstractConfigFile(String appId, String namespace, ConfigRepository configRepository) {
-    m_configRepository = configRepository;
-    m_appId = appId;
-    m_namespace = namespace;
-    m_configProperties = new AtomicReference<>();
+    this.configRepository = configRepository;
+    this.appId = appId;
+    this.namespace = namespace;
+    this.configProperties = new AtomicReference<>();
     propertiesFactory = ApolloInjector.getInstance(PropertiesFactory.class);
     initialize();
   }
 
   private void initialize() {
     try {
-      m_configProperties.set(m_configRepository.getConfig());
-      m_sourceType = m_configRepository.getSourceType();
+      configProperties.set(configRepository.getConfig());
+      sourceType = configRepository.getSourceType();
     } catch (Throwable ex) {
       Tracer.logError(ex);
       logger.warn("Init Apollo Config File failed - namespace: {}, reason: {}.",
-          m_namespace, ExceptionUtil.getDetailMessage(ex));
+          namespace, ExceptionUtil.getDetailMessage(ex));
     } finally {
       //register the change listener no matter config repository is working or not
       //so that whenever config repository is recovered, config could get changed
-      m_configRepository.addChangeListener(this);
+      configRepository.addChangeListener(this);
     }
   }
 
   @Override
   public String getAppId() {
-    return m_appId;
+    return appId;
   }
 
   @Override
   public String getNamespace() {
-    return m_namespace;
+    return namespace;
   }
 
   protected abstract void update(Properties newProperties);
 
   @Override
   public synchronized void onRepositoryChange(String namespace, Properties newProperties) {
-    this.onRepositoryChange(m_appId, m_namespace, newProperties);
+    this.onRepositoryChange(this.appId, this.namespace, newProperties);
   }
 
   @Override
   public synchronized void onRepositoryChange(String appId, String namespace, Properties newProperties) {
-    if (newProperties.equals(m_configProperties.get())) {
+    if (newProperties.equals(configProperties.get())) {
       return;
     }
     Properties newConfigProperties = propertiesFactory.getPropertiesInstance();
@@ -112,7 +112,7 @@ public abstract class AbstractConfigFile implements ConfigFile, RepositoryChange
     String oldValue = getContent();
 
     update(newProperties);
-    m_sourceType = m_configRepository.getSourceType();
+    sourceType = configRepository.getSourceType();
 
     String newValue = getContent();
 
@@ -124,31 +124,31 @@ public abstract class AbstractConfigFile implements ConfigFile, RepositoryChange
       changeType = PropertyChangeType.DELETED;
     }
 
-    this.fireConfigChange(new ConfigFileChangeEvent(m_appId, m_namespace, oldValue, newValue, changeType));
+    this.fireConfigChange(new ConfigFileChangeEvent(this.appId, this.namespace, oldValue, newValue, changeType));
 
-    Tracer.logEvent(APOLLO_CLIENT_CONFIGCHANGES, m_namespace);
+    Tracer.logEvent(APOLLO_CLIENT_CONFIGCHANGES, this.namespace);
   }
 
   @Override
   public void addChangeListener(ConfigFileChangeListener listener) {
-    if (!m_listeners.contains(listener)) {
-      m_listeners.add(listener);
+    if (!listeners.contains(listener)) {
+      listeners.add(listener);
     }
   }
 
   @Override
   public boolean removeChangeListener(ConfigFileChangeListener listener) {
-    return m_listeners.remove(listener);
+    return listeners.remove(listener);
   }
 
   @Override
   public ConfigSourceType getSourceType() {
-    return m_sourceType;
+    return sourceType;
   }
 
   private void fireConfigChange(final ConfigFileChangeEvent changeEvent) {
-    for (final ConfigFileChangeListener listener : m_listeners) {
-      m_executorService.submit(new Runnable() {
+    for (final ConfigFileChangeListener listener : listeners) {
+      executorService.submit(new Runnable() {
         @Override
         public void run() {
           String listenerName = listener.getClass().getName();

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigRepository.java
@@ -34,7 +34,7 @@ import com.google.common.collect.Lists;
  */
 public abstract class AbstractConfigRepository implements ConfigRepository {
   private static final Logger logger = LoggerFactory.getLogger(AbstractConfigRepository.class);
-  private List<RepositoryChangeListener> m_listeners = Lists.newCopyOnWriteArrayList();
+  private List<RepositoryChangeListener> listeners = Lists.newCopyOnWriteArrayList();
   protected PropertiesFactory propertiesFactory = ApolloInjector.getInstance(PropertiesFactory.class);
 
   protected boolean trySync() {
@@ -54,18 +54,18 @@ public abstract class AbstractConfigRepository implements ConfigRepository {
 
   @Override
   public void addChangeListener(RepositoryChangeListener listener) {
-    if (!m_listeners.contains(listener)) {
-      m_listeners.add(listener);
+    if (!listeners.contains(listener)) {
+      listeners.add(listener);
     }
   }
 
   @Override
   public void removeChangeListener(RepositoryChangeListener listener) {
-    m_listeners.remove(listener);
+    listeners.remove(listener);
   }
 
   protected void fireRepositoryChange(String appId, String namespace, Properties newProperties) {
-    for (RepositoryChangeListener listener : m_listeners) {
+    for (RepositoryChangeListener listener : listeners) {
       try {
         listener.onRepositoryChange(appId, namespace, newProperties);
       } catch (Throwable ex) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigMonitorInitializer.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigMonitorInitializer.java
@@ -49,10 +49,10 @@ public class ConfigMonitorInitializer {
   private static final ApolloClientMonitorContext MONITOR_CONTEXT = ApolloInjector.getInstance(
       ApolloClientMonitorContext.class);
   protected static volatile boolean hasInitialized = false;
-  private static ConfigUtil m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+  private static ConfigUtil configUtil = ApolloInjector.getInstance(ConfigUtil.class);
 
   public static void initialize() {
-    if (m_configUtil.isClientMonitorEnabled() && !hasInitialized) {
+    if (configUtil.isClientMonitorEnabled() && !hasInitialized) {
       synchronized (ConfigMonitorInitializer.class) {
         if (!hasInitialized) {
           doInit();
@@ -70,7 +70,7 @@ public class ConfigMonitorInitializer {
 
 
   private static void initializeJmxMonitoring() {
-    if (m_configUtil.isClientMonitorJmxEnabled()) {
+    if (configUtil.isClientMonitorJmxEnabled()) {
       MONITOR_CONTEXT.getApolloClientMonitorEventListeners().forEach(metricsListener ->
           ApolloClientJmxMBeanRegister.register(
               MBEAN_NAME + metricsListener.getName(), metricsListener)
@@ -82,14 +82,14 @@ public class ConfigMonitorInitializer {
     ConfigManager configManager = ApolloInjector.getInstance(
         ConfigManager.class);
     DefaultApolloClientBootstrapArgsApi defaultApolloClientBootstrapArgsApi = new DefaultApolloClientBootstrapArgsApi(
-        m_configUtil);
-    DefaultApolloClientExceptionApi defaultApolloClientExceptionApi = new DefaultApolloClientExceptionApi(m_configUtil);
+        configUtil);
+    DefaultApolloClientExceptionApi defaultApolloClientExceptionApi = new DefaultApolloClientExceptionApi(configUtil);
     DefaultApolloClientNamespaceApi defaultApolloClientNamespaceApi = new DefaultApolloClientNamespaceApi(
         configManager);
     DefaultApolloClientThreadPoolApi defaultApolloClientThreadPoolApi = new DefaultApolloClientThreadPoolApi(
-        RemoteConfigRepository.m_executorService,
-        AbstractConfig.m_executorService, AbstractConfigFile.m_executorService,
-        AbstractApolloClientMetricsExporter.m_executorService);
+        RemoteConfigRepository.executorService,
+        AbstractConfig.executorService, AbstractConfigFile.executorService,
+        AbstractApolloClientMetricsExporter.executorService);
 
     MONITOR_CONTEXT.setApolloClientBootstrapArgsMonitorApi(defaultApolloClientBootstrapArgsApi);
     MONITOR_CONTEXT.setApolloClientExceptionMonitorApi(defaultApolloClientExceptionApi);
@@ -103,7 +103,7 @@ public class ConfigMonitorInitializer {
 
   private static void initializeMetricsExporter(
   ) {
-    if (StringUtils.isBlank(m_configUtil.getMonitorExternalType())) {
+    if (StringUtils.isBlank(configUtil.getMonitorExternalType())) {
       return;
     }
     ApolloClientMetricsExporterFactory exporterFactory = ApolloInjector.getInstance(
@@ -118,7 +118,7 @@ public class ConfigMonitorInitializer {
   public static ApolloClientMessageProducerComposite initializeMessageProducerComposite() {
     List<MessageProducer> producers = ServiceBootstrap.loadAllOrdered(MessageProducer.class);
 
-    if (m_configUtil.isClientMonitorEnabled()) {
+    if (configUtil.isClientMonitorEnabled()) {
       producers.add(new ApolloClientMonitorMessageProducer());
     }
 
@@ -136,7 +136,7 @@ public class ConfigMonitorInitializer {
   // for test only
   protected static void reset() {
     hasInitialized = false;
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
 
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigServiceLocator.java
@@ -55,18 +55,18 @@ import com.google.gson.reflect.TypeToken;
 
 public class ConfigServiceLocator {
   private static final Logger logger = DeferredLoggerFactory.getLogger(ConfigServiceLocator.class);
-  private HttpClient m_httpClient;
-  private ConfigUtil m_configUtil;
-  private AtomicReference<List<ServiceDTO>> m_configServices;
-  private Type m_responseType;
-  private ScheduledExecutorService m_executorService;
+  private HttpClient httpClient;
+  private ConfigUtil configUtil;
+  private AtomicReference<List<ServiceDTO>> configServices;
+  private Type responseType;
+  private ScheduledExecutorService executorService;
   /**
-   * forbid submit multiple task to {@link #m_executorService}，
+   * forbid submit multiple task to {@link #executorService}，
    * <p>
    * so use this AtomicBoolean as a signal
    */
   protected AtomicBoolean discoveryTaskQueueMark;
-  private RateLimiter m_discoveryRateLimiter;
+  private RateLimiter discoveryRateLimiter;
   private static final Joiner.MapJoiner MAP_JOINER = Joiner.on("&").withKeyValueSeparator("=");
   private static final Escaper queryParamEscaper = UrlEscapers.urlFormParameterEscaper();
 
@@ -75,15 +75,15 @@ public class ConfigServiceLocator {
    */
   public ConfigServiceLocator() {
     List<ServiceDTO> initial = Lists.newArrayList();
-    m_configServices = new AtomicReference<>(initial);
-    m_responseType = new TypeToken<List<ServiceDTO>>() {
+    configServices = new AtomicReference<>(initial);
+    responseType = new TypeToken<List<ServiceDTO>>() {
     }.getType();
-    m_httpClient = ApolloInjector.getInstance(HttpClient.class);
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
-    this.m_executorService = Executors.newScheduledThreadPool(1,
+    httpClient = ApolloInjector.getInstance(HttpClient.class);
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    this.executorService = Executors.newScheduledThreadPool(1,
         ApolloThreadFactory.create("ConfigServiceLocator", true));
     this.discoveryTaskQueueMark = new AtomicBoolean(false);
-    this.m_discoveryRateLimiter = RateLimiter.create(m_configUtil.getDiscoveryQPS());
+    this.discoveryRateLimiter = RateLimiter.create(configUtil.getDiscoveryQPS());
     initConfigServices();
   }
 
@@ -167,7 +167,7 @@ public class ConfigServiceLocator {
   }
 
   void doSubmitUpdateTask() {
-    m_executorService.submit(() -> {
+    executorService.submit(() -> {
       boolean needUpdate = this.discoveryTaskQueueMark.getAndSet(false);
       if (needUpdate) {
         this.tryUpdateConfigServices();
@@ -191,7 +191,7 @@ public class ConfigServiceLocator {
    * @return the services dto
    */
   public List<ServiceDTO> getConfigServices() {
-    if (m_configServices.get().isEmpty()) {
+    if (configServices.get().isEmpty()) {
       trySubmitUpdateTask();
       // quick fail
       throw new ApolloConfigException(
@@ -201,7 +201,7 @@ public class ConfigServiceLocator {
       );
     }
 
-    return m_configServices.get();
+    return configServices.get();
   }
 
   private boolean tryUpdateConfigServices() {
@@ -215,7 +215,7 @@ public class ConfigServiceLocator {
   }
 
   private void schedulePeriodicRefresh() {
-    this.m_executorService.scheduleAtFixedRate(
+    this.executorService.scheduleAtFixedRate(
         new Runnable() {
           @Override
           public void run() {
@@ -223,12 +223,12 @@ public class ConfigServiceLocator {
             Tracer.logEvent(APOLLO_META_SERVICE, "periodicRefresh");
             tryUpdateConfigServices();
           }
-        }, m_configUtil.getRefreshInterval(), m_configUtil.getRefreshInterval(),
-        m_configUtil.getRefreshIntervalTimeUnit());
+        }, configUtil.getRefreshInterval(), configUtil.getRefreshInterval(),
+        configUtil.getRefreshIntervalTimeUnit());
   }
 
   synchronized boolean tryAcquireForUpdate() {
-    return this.m_discoveryRateLimiter.tryAcquire();
+    return this.discoveryRateLimiter.tryAcquire();
   }
 
   private synchronized void updateConfigServices() {
@@ -240,8 +240,8 @@ public class ConfigServiceLocator {
 
     HttpRequest request = new HttpRequest(url);
 
-    request.setConnectTimeout(m_configUtil.getDiscoveryConnectTimeout());
-    request.setReadTimeout(m_configUtil.getDiscoveryReadTimeout());
+    request.setConnectTimeout(configUtil.getDiscoveryConnectTimeout());
+    request.setReadTimeout(configUtil.getDiscoveryReadTimeout());
 
     int maxRetries = 2;
     Throwable exception = null;
@@ -250,7 +250,7 @@ public class ConfigServiceLocator {
       Transaction transaction = Tracer.newTransaction("Apollo.MetaService", "getConfigService");
       transaction.addData("Url", url);
       try {
-        HttpResponse<List<ServiceDTO>> response = m_httpClient.doGet(request, m_responseType);
+        HttpResponse<List<ServiceDTO>> response = httpClient.doGet(request, responseType);
         transaction.setStatus(Transaction.SUCCESS);
         List<ServiceDTO> services = response.getBody();
         if (services == null || services.isEmpty()) {
@@ -268,7 +268,7 @@ public class ConfigServiceLocator {
       }
 
       try {
-        m_configUtil.getOnErrorRetryIntervalTimeUnit().sleep(m_configUtil.getOnErrorRetryInterval());
+        configUtil.getOnErrorRetryIntervalTimeUnit().sleep(configUtil.getOnErrorRetryInterval());
       } catch (InterruptedException ex) {
         //ignore
       }
@@ -279,14 +279,14 @@ public class ConfigServiceLocator {
   }
 
   private void setConfigServices(List<ServiceDTO> services) {
-    m_configServices.set(services);
+    configServices.set(services);
     logConfigServices(services);
   }
 
   private String assembleMetaServiceUrl() {
-    String domainName = m_configUtil.getMetaServerDomainName();
-    String appId = m_configUtil.getAppId();
-    String localIp = m_configUtil.getLocalIp();
+    String domainName = configUtil.getMetaServerDomainName();
+    String appId = configUtil.getAppId();
+    String localIp = configUtil.getLocalIp();
 
     Map<String, String> queryParams = Maps.newHashMap();
     queryParams.put("appId", queryParamEscaper.escape(appId));

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
@@ -50,14 +50,14 @@ import com.google.common.util.concurrent.RateLimiter;
 public class DefaultConfig extends AbstractConfig implements RepositoryChangeListener {
 
   private static final Logger logger = DeferredLoggerFactory.getLogger(DefaultConfig.class);
-  private final String m_appId;
-  private final String m_namespace;
-  private final Properties m_resourceProperties;
-  private final AtomicReference<Properties> m_configProperties;
-  private final ConfigRepository m_configRepository;
-  private final RateLimiter m_warnLogRateLimiter;
+  private final String appId;
+  private final String namespace;
+  private final Properties resourceProperties;
+  private final AtomicReference<Properties> configProperties;
+  private final ConfigRepository configRepository;
+  private final RateLimiter warnLogRateLimiter;
 
-  private volatile ConfigSourceType m_sourceType = ConfigSourceType.NONE;
+  private volatile ConfigSourceType sourceType = ConfigSourceType.NONE;
 
   /**
    * Constructor.
@@ -80,27 +80,27 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
     if (appId == null) {
       appId = ApolloInjector.getInstance(ConfigUtil.class).getAppId();
     }
-    m_appId = appId;
-    m_namespace = namespace;
-    m_resourceProperties = loadFromResource(m_appId, m_namespace);
-    m_configRepository = configRepository;
-    m_configProperties = new AtomicReference<>();
-    m_warnLogRateLimiter = RateLimiter.create(0.017); // 1 warning log output per minute
+    this.appId = appId;
+    this.namespace = namespace;
+    this.resourceProperties = loadFromResource(this.appId, this.namespace);
+    this.configRepository = configRepository;
+    this.configProperties = new AtomicReference<>();
+    this.warnLogRateLimiter = RateLimiter.create(0.017); // 1 warning log output per minute
     initialize();
   }
 
   private void initialize() {
     try {
-      m_configRepository.initialize();
-      updateConfig(m_configRepository.getConfig(), m_configRepository.getSourceType());
+      configRepository.initialize();
+      updateConfig(configRepository.getConfig(), configRepository.getSourceType());
     } catch (Throwable ex) {
       Tracer.logError(ex);
       logger.warn("Init Apollo Local Config failed - namespace: {}, reason: {}.",
-          m_namespace, ExceptionUtil.getDetailMessage(ex));
+          namespace, ExceptionUtil.getDetailMessage(ex));
     } finally {
       //register the change listener no matter config repository is working or not
       //so that whenever config repository is recovered, config could get changed
-      m_configRepository.addChangeListener(this);
+      configRepository.addChangeListener(this);
     }
   }
 
@@ -111,7 +111,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
    * @return value
    */
   protected String getPropertyFromRepository(String key) {
-    Properties properties = m_configProperties.get();
+    Properties properties = configProperties.get();
     if (properties != null) {
       return properties.getProperty(key);
     }
@@ -125,7 +125,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
    * @return value
    */
   protected String getPropertyFromAdditional(String key) {
-    Properties properties = this.m_resourceProperties;
+    Properties properties = this.resourceProperties;
     if (properties != null) {
       return properties.getProperty(key);
     }
@@ -138,10 +138,10 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
    * @param value value
    */
   protected void tryWarnLog(String value) {
-    if (value == null && m_configProperties.get() == null && m_warnLogRateLimiter.tryAcquire()) {
+    if (value == null && configProperties.get() == null && warnLogRateLimiter.tryAcquire()) {
       logger.warn(
           "Could not load config for namespace {} from Apollo, please check whether the configs are released in Apollo! Return default value now!",
-          m_namespace);
+          namespace);
     }
   }
 
@@ -151,7 +151,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
    * @return property names
    */
   protected Set<String> getPropertyNamesFromRepository() {
-    Properties properties = m_configProperties.get();
+    Properties properties = configProperties.get();
     if (properties == null) {
       return Collections.emptySet();
     }
@@ -164,7 +164,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
    * @return property names
    */
   protected Set<String> getPropertyNamesFromAdditional() {
-    Properties properties = m_resourceProperties;
+    Properties properties = resourceProperties;
     if (properties == null) {
       return Collections.emptySet();
     }
@@ -220,7 +220,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
 
   @Override
   public ConfigSourceType getSourceType() {
-    return m_sourceType;
+    return sourceType;
   }
 
   private Set<String> stringPropertyNames(Properties properties) {
@@ -238,16 +238,16 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
 
   @Override
   public synchronized void onRepositoryChange(String namespace, Properties newProperties) {
-    this.onRepositoryChange(m_appId, m_namespace, newProperties);
+    this.onRepositoryChange(this.appId, this.namespace, newProperties);
   }
 
   @Override
   public synchronized void onRepositoryChange(String appId, String namespace, Properties newProperties) {
-    if (newProperties.equals(m_configProperties.get())) {
+    if (newProperties.equals(configProperties.get())) {
       return;
     }
 
-    ConfigSourceType sourceType = m_configRepository.getSourceType();
+    ConfigSourceType sourceType = configRepository.getSourceType();
     Properties newConfigProperties = propertiesFactory.getPropertiesInstance();
     newConfigProperties.putAll(newProperties);
 
@@ -259,20 +259,20 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
       return;
     }
 
-    this.fireConfigChange(m_appId, m_namespace, actualChanges);
+    this.fireConfigChange(this.appId, this.namespace, actualChanges);
 
-    Tracer.logEvent(APOLLO_CLIENT_CONFIGCHANGES, m_namespace);
+    Tracer.logEvent(APOLLO_CLIENT_CONFIGCHANGES, this.namespace);
   }
 
   private void updateConfig(Properties newConfigProperties, ConfigSourceType sourceType) {
-    m_configProperties.set(newConfigProperties);
-    m_sourceType = sourceType;
+    configProperties.set(newConfigProperties);
+    this.sourceType = sourceType;
   }
 
   private Map<String, ConfigChange> updateAndCalcConfigChanges(Properties newConfigProperties,
       ConfigSourceType sourceType) {
     List<ConfigChange> configChanges =
-        calcPropertyChanges(m_appId, m_namespace, m_configProperties.get(), newConfigProperties);
+        calcPropertyChanges(appId, namespace, configProperties.get(), newConfigProperties);
 
     ImmutableMap.Builder<String, ConfigChange> actualChanges =
         new ImmutableMap.Builder<>();
@@ -284,7 +284,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
       change.setOldValue(this.getProperty(change.getPropertyName(), change.getOldValue()));
     }
 
-    //2. update m_configProperties
+    //2. update configProperties
     updateConfig(newConfigProperties, sourceType);
     clearConfigCache();
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfigManager.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfigManager.java
@@ -37,43 +37,43 @@ import java.util.Map;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class DefaultConfigManager implements ConfigManager {
-  private ConfigFactoryManager m_factoryManager;
+  private ConfigFactoryManager factoryManager;
 
-  private ConfigUtil m_configUtil;
+  private ConfigUtil configUtil;
 
-  private Table<String, String, Config> m_configs = Tables.synchronizedTable(HashBasedTable.create());
+  private Table<String, String, Config> configs = Tables.synchronizedTable(HashBasedTable.create());
 
-  private Map<String, Object> m_configLocks = Maps.newConcurrentMap();
+  private Map<String, Object> configLocks = Maps.newConcurrentMap();
 
-  private Table<String, String, ConfigFile> m_configFiles = Tables.synchronizedTable(HashBasedTable.create());
+  private Table<String, String, ConfigFile> configFiles = Tables.synchronizedTable(HashBasedTable.create());
 
-  private Map<String, Object> m_configFileLocks = Maps.newConcurrentMap();
+  private Map<String, Object> configFileLocks = Maps.newConcurrentMap();
 
 
   public DefaultConfigManager() {
-    m_factoryManager = ApolloInjector.getInstance(ConfigFactoryManager.class);
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    factoryManager = ApolloInjector.getInstance(ConfigFactoryManager.class);
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
   }
 
   @Override
   public Config getConfig(String namespace) {
-    return getConfig(m_configUtil.getAppId(), namespace);
+    return getConfig(configUtil.getAppId(), namespace);
   }
     
   @Override
   public Config getConfig(String appId, String namespace) {
-    Config config = m_configs.get(appId, namespace);
+    Config config = configs.get(appId, namespace);
 
     if (config == null) {
-      Object lock = m_configLocks.computeIfAbsent(String.format("%s.%s", appId, namespace), key -> new Object());
+      Object lock = configLocks.computeIfAbsent(String.format("%s.%s", appId, namespace), key -> new Object());
       synchronized (lock) {
-        config = m_configs.get(appId, namespace);
+        config = configs.get(appId, namespace);
 
         if (config == null) {
-          ConfigFactory factory = m_factoryManager.getFactory(appId, namespace);
+          ConfigFactory factory = factoryManager.getFactory(appId, namespace);
 
           config = factory.create(appId, namespace);
-          m_configs.put(appId, namespace, config);
+          configs.put(appId, namespace, config);
         }
       }
     }
@@ -86,25 +86,25 @@ public class DefaultConfigManager implements ConfigManager {
 
   @Override
   public ConfigFile getConfigFile(String namespace, ConfigFileFormat configFileFormat) {
-    return getConfigFile(m_configUtil.getAppId(), namespace, configFileFormat);
+    return getConfigFile(configUtil.getAppId(), namespace, configFileFormat);
   }
 
   @Override
   public ConfigFile getConfigFile(String appId, String namespace, ConfigFileFormat configFileFormat) {
     String namespaceFileName = String.format("%s.%s", namespace, configFileFormat.getValue());
     String lockNamespaceFileName = String.format("%s+%s.%s", appId, namespace, configFileFormat.getValue());
-    ConfigFile configFile = m_configFiles.get(appId, namespaceFileName);
+    ConfigFile configFile = configFiles.get(appId, namespaceFileName);
 
     if (configFile == null) {
-      Object lock = m_configFileLocks.computeIfAbsent(lockNamespaceFileName, key -> new Object());
+      Object lock = configFileLocks.computeIfAbsent(lockNamespaceFileName, key -> new Object());
       synchronized (lock) {
-        configFile = m_configFiles.get(appId, namespaceFileName);
+        configFile = configFiles.get(appId, namespaceFileName);
 
         if (configFile == null) {
-          ConfigFactory factory = m_factoryManager.getFactory(appId, namespaceFileName);
+          ConfigFactory factory = factoryManager.getFactory(appId, namespaceFileName);
 
           configFile = factory.createConfigFile(appId, namespaceFileName, configFileFormat);
-          m_configFiles.put(appId, namespaceFileName, configFile);
+          configFiles.put(appId, namespaceFileName, configFile);
         }
       }
     }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultInjector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultInjector.java
@@ -47,13 +47,13 @@ import java.util.List;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class DefaultInjector implements Injector {
-  private final com.google.inject.Injector m_injector;
-  private final List<ApolloInjectorCustomizer> m_customizers;
+  private final com.google.inject.Injector injector;
+  private final List<ApolloInjectorCustomizer> customizers;
 
   public DefaultInjector() {
     try {
-      m_injector = Guice.createInjector(new ApolloModule());
-      m_customizers = ServiceBootstrap.loadAllOrdered(ApolloInjectorCustomizer.class);
+      injector = Guice.createInjector(new ApolloModule());
+      customizers = ServiceBootstrap.loadAllOrdered(ApolloInjectorCustomizer.class);
     } catch (Throwable ex) {
       ApolloConfigException exception = new ApolloConfigException("Unable to initialize Guice Injector!", ex);
       Tracer.logError(exception);
@@ -64,13 +64,13 @@ public class DefaultInjector implements Injector {
   @Override
   public <T> T getInstance(Class<T> clazz) {
     try {
-      for (ApolloInjectorCustomizer customizer : m_customizers) {
+      for (ApolloInjectorCustomizer customizer : customizers) {
         T instance = customizer.getInstance(clazz);
         if (instance != null) {
           return instance;
         }
       }
-      return m_injector.getInstance(clazz);
+      return injector.getInstance(clazz);
     } catch (Throwable ex) {
       Tracer.logError(ex);
       throw new ApolloConfigException(
@@ -81,7 +81,7 @@ public class DefaultInjector implements Injector {
   @Override
   public <T> T getInstance(Class<T> clazz, String name) {
     try {
-      for (ApolloInjectorCustomizer customizer : m_customizers) {
+      for (ApolloInjectorCustomizer customizer : customizers) {
         T instance = customizer.getInstance(clazz, name);
         if (instance != null) {
           return instance;

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/InterestedConfigChangeEvent.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/InterestedConfigChangeEvent.java
@@ -39,12 +39,12 @@ class InterestedConfigChangeEvent extends ConfigChangeEvent {
    * @see ApolloConfigChangeListener#interestedKeys()
    * @see ApolloConfigChangeListener#interestedKeyPrefixes()
    */
-  private final Set<String> m_interestedChangedKeys;
+  private final Set<String> interestedChangedKeys;
 
   public InterestedConfigChangeEvent(String appId, String namespace,
       Map<String, ConfigChange> changes, Set<String> interestedChangedKeys) {
     super(appId, namespace, changes);
-    this.m_interestedChangedKeys = interestedChangedKeys;
+    this.interestedChangedKeys = interestedChangedKeys;
   }
 
   /**
@@ -52,6 +52,6 @@ class InterestedConfigChangeEvent extends ConfigChangeEvent {
    */
   @Override
   public Set<String> interestedChangedKeys() {
-    return Collections.unmodifiableSet(this.m_interestedChangedKeys);
+    return Collections.unmodifiableSet(this.interestedChangedKeys);
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepository.java
@@ -50,14 +50,14 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
     implements RepositoryChangeListener {
   private static final Logger logger = DeferredLoggerFactory.getLogger(LocalFileConfigRepository.class);
   private static final String CONFIG_DIR = "/config-cache";
-  private final String m_appId;
-  private final String m_namespace;
-  private File m_baseDir;
-  private final ConfigUtil m_configUtil;
-  private volatile Properties m_fileProperties;
-  private volatile ConfigRepository m_upstream;
+  private final String appId;
+  private final String namespace;
+  private File baseDir;
+  private final ConfigUtil configUtil;
+  private volatile Properties fileProperties;
+  private volatile ConfigRepository upstream;
 
-  private volatile ConfigSourceType m_sourceType = ConfigSourceType.LOCAL;
+  private volatile ConfigSourceType sourceType = ConfigSourceType.LOCAL;
 
   /**
    * Constructor.
@@ -69,16 +69,16 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
   }
 
   public LocalFileConfigRepository(String appId, String namespace, ConfigRepository upstream) {
-    m_appId = appId;
-    m_namespace = namespace;
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    this.appId = appId;
+    this.namespace = namespace;
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
     this.setLocalCacheDir(findLocalCacheDir(), false);
     this.setUpstreamRepository(upstream);
   }
 
   void setLocalCacheDir(File baseDir, boolean syncImmediately) {
-    m_baseDir = baseDir;
-    this.checkLocalConfigCacheDir(m_baseDir);
+    this.baseDir = baseDir;
+    this.checkLocalConfigCacheDir(this.baseDir);
     if (syncImmediately) {
       this.trySync();
     }
@@ -86,7 +86,7 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
 
   private File findLocalCacheDir() {
     try {
-      String defaultCacheDir = m_configUtil.getDefaultLocalCacheDir(m_appId);
+      String defaultCacheDir = configUtil.getDefaultLocalCacheDir(appId);
       Path path = Paths.get(defaultCacheDir);
       if (!Files.exists(path)) {
         Files.createDirectories(path);
@@ -103,11 +103,11 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
 
   @Override
   public Properties getConfig() {
-    if (m_fileProperties == null) {
+    if (fileProperties == null) {
       sync();
     }
     Properties result = propertiesFactory.getPropertiesInstance();
-    result.putAll(m_fileProperties);
+    result.putAll(fileProperties);
     return result;
   }
 
@@ -117,31 +117,31 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
       return;
     }
     //clear previous listener
-    if (m_upstream != null) {
-      m_upstream.removeChangeListener(this);
+    if (upstream != null) {
+      upstream.removeChangeListener(this);
     }
-    m_upstream = upstreamConfigRepository;
+    upstream = upstreamConfigRepository;
     upstreamConfigRepository.addChangeListener(this);
   }
 
   @Override
   public ConfigSourceType getSourceType() {
-    return m_sourceType;
+    return sourceType;
   }
 
   @Override
   public void onRepositoryChange(String namespace, Properties newProperties) {
-    this.onRepositoryChange(m_appId, namespace, newProperties);
+    this.onRepositoryChange(appId, namespace, newProperties);
   }
 
   @Override
   public void onRepositoryChange(String appId, String namespace, Properties newProperties) {
-    if (newProperties.equals(m_fileProperties)) {
+    if (newProperties.equals(fileProperties)) {
       return;
     }
     Properties newFileProperties = propertiesFactory.getPropertiesInstance();
     newFileProperties.putAll(newProperties);
-    updateFileProperties(newFileProperties, m_upstream.getSourceType());
+    updateFileProperties(newFileProperties, upstream.getSourceType());
     this.fireRepositoryChange(appId, namespace, newProperties);
   }
 
@@ -157,9 +157,9 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
     Transaction transaction = Tracer.newTransaction("Apollo.ConfigService", "syncLocalConfig");
     Throwable exception = null;
     try {
-      transaction.addData("Basedir", m_baseDir.getAbsolutePath());
-      m_fileProperties = this.loadFromLocalCacheFile(m_baseDir, m_appId, m_namespace);
-      m_sourceType = ConfigSourceType.LOCAL;
+      transaction.addData("Basedir", baseDir.getAbsolutePath());
+      fileProperties = this.loadFromLocalCacheFile(baseDir, appId, namespace);
+      sourceType = ConfigSourceType.LOCAL;
       transaction.setStatus(Transaction.SUCCESS);
     } catch (Throwable ex) {
       Tracer.logEvent(APOLLO_CONFIG_EXCEPTION, ExceptionUtil.getDetailMessage(ex));
@@ -170,36 +170,36 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
       transaction.complete();
     }
 
-    if (m_fileProperties == null) {
-      m_sourceType = ConfigSourceType.NONE;
+    if (fileProperties == null) {
+      sourceType = ConfigSourceType.NONE;
       throw new ApolloConfigException(
           "Load config from local config failed!", exception);
     }
   }
 
   private boolean trySyncFromUpstream() {
-    if (m_upstream == null) {
+    if (upstream == null) {
       return false;
     }
     try {
-      updateFileProperties(m_upstream.getConfig(), m_upstream.getSourceType());
+      updateFileProperties(upstream.getConfig(), upstream.getSourceType());
       return true;
     } catch (Throwable ex) {
       Tracer.logError(ex);
       logger
-          .warn("Sync config from upstream repository {} failed, reason: {}", m_upstream.getClass(),
+          .warn("Sync config from upstream repository {} failed, reason: {}", upstream.getClass(),
               ExceptionUtil.getDetailMessage(ex));
     }
     return false;
   }
 
   private synchronized void updateFileProperties(Properties newProperties, ConfigSourceType sourceType) {
-    this.m_sourceType = sourceType;
-    if (newProperties.equals(m_fileProperties)) {
+    this.sourceType = sourceType;
+    if (newProperties.equals(fileProperties)) {
       return;
     }
-    this.m_fileProperties = newProperties;
-    persistLocalCacheFile(m_baseDir, m_appId, m_namespace);
+    this.fileProperties = newProperties;
+    persistLocalCacheFile(baseDir, appId, namespace);
   }
 
   private Properties loadFromLocalCacheFile(File baseDir, String appId, String namespace) throws IOException {
@@ -249,7 +249,7 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
     transaction.addData("LocalConfigFile", file.getAbsolutePath());
     try {
       out = new FileOutputStream(file);
-      m_fileProperties.store(out, "Persisted by DefaultConfig");
+      fileProperties.store(out, "Persisted by DefaultConfig");
       transaction.setStatus(Transaction.SUCCESS);
     } catch (IOException ex) {
       ApolloConfigException exception =
@@ -298,7 +298,7 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
   File assembleLocalCacheFile(File baseDir, String appId, String namespace) {
     String fileName =
         String.format("%s.properties", Joiner.on(ConfigConsts.CLUSTER_NAMESPACE_SEPARATOR)
-            .join(appId, m_configUtil.getCluster(), namespace));
+            .join(appId, configUtil.getCluster(), namespace));
     return new File(baseDir, fileName);
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PlainTextConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PlainTextConfigFile.java
@@ -33,19 +33,19 @@ public abstract class PlainTextConfigFile extends AbstractConfigFile {
     if (!this.hasContent()) {
       return null;
     }
-    return m_configProperties.get().getProperty(ConfigConsts.CONFIG_FILE_CONTENT_KEY);
+    return configProperties.get().getProperty(ConfigConsts.CONFIG_FILE_CONTENT_KEY);
   }
 
   @Override
   public boolean hasContent() {
-    if (m_configProperties.get() == null) {
+    if (configProperties.get() == null) {
       return false;
     }
-    return m_configProperties.get().containsKey(ConfigConsts.CONFIG_FILE_CONTENT_KEY);
+    return configProperties.get().containsKey(ConfigConsts.CONFIG_FILE_CONTENT_KEY);
   }
 
   @Override
   protected void update(Properties newProperties) {
-    m_configProperties.set(newProperties);
+    configProperties.set(newProperties);
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PropertiesConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PropertiesConfigFile.java
@@ -34,26 +34,26 @@ import java.util.concurrent.atomic.AtomicReference;
 public class PropertiesConfigFile extends AbstractConfigFile implements
     PropertiesCompatibleConfigFile {
 
-  protected AtomicReference<String> m_contentCache;
+  protected AtomicReference<String> contentCache;
 
   public PropertiesConfigFile(String appId, String namespace,
       ConfigRepository configRepository) {
     super(appId, namespace, configRepository);
-    m_contentCache = new AtomicReference<>();
+    contentCache = new AtomicReference<>();
   }
 
   @Override
   protected void update(Properties newProperties) {
-    m_configProperties.set(newProperties);
-    m_contentCache.set(null);
+    configProperties.set(newProperties);
+    contentCache.set(null);
   }
 
   @Override
   public String getContent() {
-    if (m_contentCache.get() == null) {
-      m_contentCache.set(doGetContent());
+    if (contentCache.get() == null) {
+      contentCache.set(doGetContent());
     }
-    return m_contentCache.get();
+    return contentCache.get();
   }
 
   String doGetContent() {
@@ -62,12 +62,12 @@ public class PropertiesConfigFile extends AbstractConfigFile implements
     }
 
     try {
-      return PropertiesUtil.toString(m_configProperties.get());
+      return PropertiesUtil.toString(configProperties.get());
     } catch (Throwable ex) {
       ApolloConfigException exception =
           new ApolloConfigException(String
               .format("Parse properties file content failed for namespace: %s, cause: %s",
-                  m_namespace, ExceptionUtil.getDetailMessage(ex)));
+                  namespace, ExceptionUtil.getDetailMessage(ex)));
       Tracer.logError(exception);
       throw exception;
     }
@@ -75,7 +75,7 @@ public class PropertiesConfigFile extends AbstractConfigFile implements
 
   @Override
   public boolean hasContent() {
-    return m_configProperties.get() != null && !m_configProperties.get().isEmpty();
+    return configProperties.get() != null && !configProperties.get().isEmpty();
   }
 
   @Override
@@ -85,6 +85,6 @@ public class PropertiesConfigFile extends AbstractConfigFile implements
 
   @Override
   public Properties asProperties() {
-      return this.hasContent() ? m_configProperties.get() : propertiesFactory.getPropertiesInstance();
+      return this.hasContent() ? configProperties.get() : propertiesFactory.getPropertiesInstance();
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigLongPollService.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigLongPollService.java
@@ -73,19 +73,19 @@ public class RemoteConfigLongPollService {
   private static final long INIT_NOTIFICATION_ID = ConfigConsts.NOTIFICATION_ID_PLACEHOLDER;
   //90 seconds, should be longer than server side's long polling timeout, which is now 60 seconds
   private static final int LONG_POLLING_READ_TIMEOUT = 90 * 1000;
-  private final ExecutorService m_longPollingService;
-  private final AtomicBoolean m_longPollingStopped;
-  private SchedulePolicy m_longPollFailSchedulePolicyInSecond;
-  private RateLimiter m_longPollRateLimiter;
-  private final ConcurrentMap<String, Boolean> m_longPollStarted;
-  private final Map<String, Multimap<String, RemoteConfigRepository>> m_longPollNamespaces;
-  private final Table<String, String, Long> m_notifications;
-  private final Map<String, ApolloNotificationMessages> m_remoteNotificationMessages;//namespaceName -> watchedKey -> notificationId
-  private Type m_responseType;
+  private final ExecutorService longPollingService;
+  private final AtomicBoolean longPollingStopped;
+  private SchedulePolicy longPollFailSchedulePolicyInSecond;
+  private RateLimiter longPollRateLimiter;
+  private final ConcurrentMap<String, Boolean> longPollStarted;
+  private final Map<String, Multimap<String, RemoteConfigRepository>> longPollNamespaces;
+  private final Table<String, String, Long> notifications;
+  private final Map<String, ApolloNotificationMessages> remoteNotificationMessages;//namespaceName -> watchedKey -> notificationId
+  private Type responseType;
   private static final Gson GSON = new Gson();
-  private ConfigUtil m_configUtil;
-  private HttpClient m_httpClient;
-  private ConfigServiceLocator m_serviceLocator;
+  private ConfigUtil configUtil;
+  private HttpClient httpClient;
+  private ConfigServiceLocator serviceLocator;
   private final ConfigServiceLoadBalancerClient configServiceLoadBalancerClient = ServiceBootstrap.loadPrimary(
       ConfigServiceLoadBalancerClient.class);
 
@@ -93,45 +93,45 @@ public class RemoteConfigLongPollService {
    * Constructor.
    */
   public RemoteConfigLongPollService() {
-    m_longPollFailSchedulePolicyInSecond = new ExponentialSchedulePolicy(1, 120); //in second
-    m_longPollingStopped = new AtomicBoolean(false);
-    m_longPollingService = Executors.newCachedThreadPool(
+    longPollFailSchedulePolicyInSecond = new ExponentialSchedulePolicy(1, 120); //in second
+    longPollingStopped = new AtomicBoolean(false);
+    longPollingService = Executors.newCachedThreadPool(
         ApolloThreadFactory.create("RemoteConfigLongPollService", true));
-    m_longPollStarted = new ConcurrentHashMap<>();
-    m_longPollNamespaces = Maps.newConcurrentMap();
-    m_notifications = Tables.synchronizedTable(HashBasedTable.<String, String, Long>create());
-    m_remoteNotificationMessages = Maps.newConcurrentMap();
-    m_responseType = new TypeToken<List<ApolloConfigNotification>>() {
+    longPollStarted = new ConcurrentHashMap<>();
+    longPollNamespaces = Maps.newConcurrentMap();
+    notifications = Tables.synchronizedTable(HashBasedTable.<String, String, Long>create());
+    remoteNotificationMessages = Maps.newConcurrentMap();
+    responseType = new TypeToken<List<ApolloConfigNotification>>() {
     }.getType();
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
-    m_httpClient = ApolloInjector.getInstance(HttpClient.class);
-    m_serviceLocator = ApolloInjector.getInstance(ConfigServiceLocator.class);
-    m_longPollRateLimiter = RateLimiter.create(m_configUtil.getLongPollQPS());
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    httpClient = ApolloInjector.getInstance(HttpClient.class);
+    serviceLocator = ApolloInjector.getInstance(ConfigServiceLocator.class);
+    longPollRateLimiter = RateLimiter.create(configUtil.getLongPollQPS());
   }
 
   public boolean submit(String appId, String namespace, RemoteConfigRepository remoteConfigRepository) {
-    Multimap<String, RemoteConfigRepository> repositoryMultimap = m_longPollNamespaces.computeIfAbsent(
+    Multimap<String, RemoteConfigRepository> repositoryMultimap = longPollNamespaces.computeIfAbsent(
                    appId, k -> Multimaps.synchronizedSetMultimap(HashMultimap.create()));
     boolean result = repositoryMultimap.put(namespace, remoteConfigRepository);
-    m_notifications.put(appId, namespace, INIT_NOTIFICATION_ID);
-    if (m_longPollStarted.get(appId) == null) {
+    notifications.put(appId, namespace, INIT_NOTIFICATION_ID);
+    if (longPollStarted.get(appId) == null) {
       startLongPolling(appId);
     }
     return result;
   }
 
   private void startLongPolling(String sysAppId) {
-    if (Boolean.TRUE.equals(m_longPollStarted.putIfAbsent(sysAppId, true))) {
+    if (Boolean.TRUE.equals(longPollStarted.putIfAbsent(sysAppId, true))) {
       //already started
       return;
     }
     try {
       final String appId = sysAppId;
-      final String cluster = m_configUtil.getCluster();
-      final String dataCenter = m_configUtil.getDataCenter();
-      final String secret = m_configUtil.getAccessKeySecret(appId);
-      final long longPollingInitialDelayInMills = m_configUtil.getLongPollingInitialDelayInMills();
-      m_longPollingService.submit(new Runnable() {
+      final String cluster = configUtil.getCluster();
+      final String dataCenter = configUtil.getDataCenter();
+      final String secret = configUtil.getAccessKeySecret(appId);
+      final long longPollingInitialDelayInMills = configUtil.getLongPollingInitialDelayInMills();
+      longPollingService.submit(new Runnable() {
         @Override
         public void run() {
           if (longPollingInitialDelayInMills > 0) {
@@ -146,7 +146,7 @@ public class RemoteConfigLongPollService {
         }
       });
     } catch (Throwable ex) {
-      m_longPollStarted.remove(sysAppId);
+      longPollStarted.remove(sysAppId);
       ApolloConfigException exception =
           new ApolloConfigException("Schedule long polling refresh failed", ex);
       Tracer.logError(exception);
@@ -155,13 +155,13 @@ public class RemoteConfigLongPollService {
   }
 
   void stopLongPollingRefresh() {
-    this.m_longPollingStopped.compareAndSet(false, true);
+    this.longPollingStopped.compareAndSet(false, true);
   }
 
   private void doLongPollingRefresh(String appId, String cluster, String dataCenter, String secret) {
     ServiceDTO lastServiceDto = null;
-    while (!m_longPollingStopped.get() && !Thread.currentThread().isInterrupted()) {
-      if (!m_longPollRateLimiter.tryAcquire(5, TimeUnit.SECONDS)) {
+    while (!longPollingStopped.get() && !Thread.currentThread().isInterrupted()) {
+      if (!longPollRateLimiter.tryAcquire(5, TimeUnit.SECONDS)) {
         //wait at most 5 seconds
         try {
           TimeUnit.SECONDS.sleep(5);
@@ -177,7 +177,7 @@ public class RemoteConfigLongPollService {
 
         url =
             assembleLongPollRefreshUrl(lastServiceDto.getHomepageUrl(), appId, cluster, dataCenter,
-                m_notifications.row(appId));
+                notifications.row(appId));
 
         logger.debug("Long polling from {}", url);
 
@@ -191,7 +191,7 @@ public class RemoteConfigLongPollService {
         transaction.addData("Url", url);
 
         final HttpResponse<List<ApolloConfigNotification>> response =
-            m_httpClient.doGet(request, m_responseType);
+            httpClient.doGet(request, responseType);
 
         logger.debug("Long polling response: {}, url: {}", response.getStatusCode(), url);
         if (response.getStatusCode() == 200 && response.getBody() != null) {
@@ -206,14 +206,14 @@ public class RemoteConfigLongPollService {
           lastServiceDto = null;
         }
 
-        m_longPollFailSchedulePolicyInSecond.success();
+        longPollFailSchedulePolicyInSecond.success();
         transaction.addData("StatusCode", response.getStatusCode());
         transaction.setStatus(Transaction.SUCCESS);
       } catch (Throwable ex) {
         lastServiceDto = null;
         Tracer.logEvent(APOLLO_CONFIG_EXCEPTION, ExceptionUtil.getDetailMessage(ex));
         transaction.setStatus(ex);
-        long sleepTimeInSecond = m_longPollFailSchedulePolicyInSecond.fail();
+        long sleepTimeInSecond = longPollFailSchedulePolicyInSecond.fail();
         if (ex.getCause() instanceof SocketTimeoutException) {
           Tracer.logEvent(APOLLO_CLIENT_NAMESPACE_TIMEOUT, assembleNamespaces(appId));
         }
@@ -235,7 +235,7 @@ public class RemoteConfigLongPollService {
     if (notifications == null || notifications.isEmpty()) {
       return;
     }
-    Multimap<String, RemoteConfigRepository> namespaceRepositories = m_longPollNamespaces.get(appId);
+    Multimap<String, RemoteConfigRepository> namespaceRepositories = longPollNamespaces.get(appId);
     if (namespaceRepositories == null) {
          return;
     }
@@ -244,7 +244,7 @@ public class RemoteConfigLongPollService {
       //create a new list to avoid ConcurrentModificationException
       List<RemoteConfigRepository> toBeNotified =
                Lists.newArrayList(namespaceRepositories.get(namespaceName));
-      ApolloNotificationMessages originalMessages = m_remoteNotificationMessages.get(namespaceName);
+      ApolloNotificationMessages originalMessages = remoteNotificationMessages.get(namespaceName);
       ApolloNotificationMessages remoteMessages = originalMessages == null ? null : originalMessages.clone();
       //since .properties are filtered out by default, so we need to check if there is any listener for it
       toBeNotified.addAll(namespaceRepositories.get(
@@ -265,14 +265,14 @@ public class RemoteConfigLongPollService {
         continue;
       }
       String namespaceName = notification.getNamespaceName();
-      if (m_notifications.contains(appId, namespaceName)) {
-        m_notifications.put(appId, namespaceName, notification.getNotificationId());
+      if (notifications.contains(appId, namespaceName)) {
+        notifications.put(appId, namespaceName, notification.getNotificationId());
       }
       //since .properties are filtered out by default, so we need to check if there is notification with .properties suffix
       String namespaceNameWithPropertiesSuffix =
           String.format("%s.%s", namespaceName, ConfigFileFormat.Properties.getValue());
-      if (m_notifications.contains(appId, namespaceNameWithPropertiesSuffix)) {
-        m_notifications.put(appId, namespaceNameWithPropertiesSuffix, notification.getNotificationId());
+      if (notifications.contains(appId, namespaceNameWithPropertiesSuffix)) {
+        notifications.put(appId, namespaceNameWithPropertiesSuffix, notification.getNotificationId());
       }
     }
   }
@@ -288,10 +288,10 @@ public class RemoteConfigLongPollService {
       }
 
       ApolloNotificationMessages localRemoteMessages =
-          m_remoteNotificationMessages.get(notification.getNamespaceName());
+          remoteNotificationMessages.get(notification.getNamespaceName());
       if (localRemoteMessages == null) {
         localRemoteMessages = new ApolloNotificationMessages();
-        m_remoteNotificationMessages.put(notification.getNamespaceName(), localRemoteMessages);
+        remoteNotificationMessages.put(notification.getNamespaceName(), localRemoteMessages);
       }
 
       localRemoteMessages.mergeFrom(notification.getMessages());
@@ -299,7 +299,7 @@ public class RemoteConfigLongPollService {
   }
 
   private String assembleNamespaces(String appId) {
-    Multimap<String, RemoteConfigRepository> namespaceRepositories = m_longPollNamespaces.get(appId);
+    Multimap<String, RemoteConfigRepository> namespaceRepositories = longPollNamespaces.get(appId);
     if (namespaceRepositories == null) {
       return "";
     }
@@ -317,7 +317,7 @@ public class RemoteConfigLongPollService {
     if (!Strings.isNullOrEmpty(dataCenter)) {
       queryParams.put("dataCenter", queryParamEscaper.escape(dataCenter));
     }
-    String localIp = m_configUtil.getLocalIp();
+    String localIp = configUtil.getLocalIp();
     if (!Strings.isNullOrEmpty(localIp)) {
       queryParams.put("ip", queryParamEscaper.escape(localIp));
     }
@@ -345,7 +345,7 @@ public class RemoteConfigLongPollService {
   }
 
   private List<ServiceDTO> getConfigServices() {
-    List<ServiceDTO> services = m_serviceLocator.getConfigServices();
+    List<ServiceDTO> services = serviceLocator.getConfigServices();
     if (services.isEmpty()) {
       throw new ApolloConfigException("No available config service");
     }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
@@ -73,23 +73,23 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
   private static final Escaper pathEscaper = UrlEscapers.urlPathSegmentEscaper();
   private static final Escaper queryParamEscaper = UrlEscapers.urlFormParameterEscaper();
 
-  private final ConfigServiceLocator m_serviceLocator;
-  private final HttpClient m_httpClient;
-  private final ConfigUtil m_configUtil;
+  private final ConfigServiceLocator serviceLocator;
+  private final HttpClient httpClient;
+  private final ConfigUtil configUtil;
   private final RemoteConfigLongPollService remoteConfigLongPollService;
-  private volatile AtomicReference<ApolloConfig> m_configCache;
-  private final String m_appId;
-  private final String m_namespace;
-  protected final static ScheduledExecutorService m_executorService;
-  private final AtomicReference<ServiceDTO> m_longPollServiceDto;
-  private final AtomicReference<ApolloNotificationMessages> m_remoteMessages;
-  private final RateLimiter m_loadConfigRateLimiter;
-  private final AtomicBoolean m_configNeedForceRefresh;
-  private final SchedulePolicy m_loadConfigFailSchedulePolicy;
+  private volatile AtomicReference<ApolloConfig> configCache;
+  private final String appId;
+  private final String namespace;
+  protected final static ScheduledExecutorService executorService;
+  private final AtomicReference<ServiceDTO> longPollServiceDto;
+  private final AtomicReference<ApolloNotificationMessages> remoteMessages;
+  private final RateLimiter loadConfigRateLimiter;
+  private final AtomicBoolean configNeedForceRefresh;
+  private final SchedulePolicy loadConfigFailSchedulePolicy;
   private static final Gson GSON = new Gson();
 
   static {
-    m_executorService = Executors.newScheduledThreadPool(1,
+    executorService = Executors.newScheduledThreadPool(1,
         ApolloThreadFactory.create("RemoteConfigRepository", true));
   }
 
@@ -100,32 +100,32 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
    * @param namespace the namespace
    */
   public RemoteConfigRepository(String appId, String namespace) {
-    m_appId = appId;
-    m_namespace = namespace;
-    m_configCache = new AtomicReference<>();
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
-    m_httpClient = ApolloInjector.getInstance(HttpClient.class);
-    m_serviceLocator = ApolloInjector.getInstance(ConfigServiceLocator.class);
+    this.appId = appId;
+    this.namespace = namespace;
+    configCache = new AtomicReference<>();
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    httpClient = ApolloInjector.getInstance(HttpClient.class);
+    serviceLocator = ApolloInjector.getInstance(ConfigServiceLocator.class);
     remoteConfigLongPollService = ApolloInjector.getInstance(RemoteConfigLongPollService.class);
-    m_longPollServiceDto = new AtomicReference<>();
-    m_remoteMessages = new AtomicReference<>();
-    m_loadConfigRateLimiter = RateLimiter.create(m_configUtil.getLoadConfigQPS());
-    m_configNeedForceRefresh = new AtomicBoolean(true);
-    m_loadConfigFailSchedulePolicy = new ExponentialSchedulePolicy(m_configUtil.getOnErrorRetryInterval(),
-        m_configUtil.getOnErrorRetryInterval() * 8);
+    longPollServiceDto = new AtomicReference<>();
+    remoteMessages = new AtomicReference<>();
+    loadConfigRateLimiter = RateLimiter.create(configUtil.getLoadConfigQPS());
+    configNeedForceRefresh = new AtomicBoolean(true);
+    loadConfigFailSchedulePolicy = new ExponentialSchedulePolicy(configUtil.getOnErrorRetryInterval(),
+        configUtil.getOnErrorRetryInterval() * 8);
     this.schedulePeriodicRefresh();
     this.scheduleLongPollingRefresh();
   }
 
   @Override
   public Properties getConfig() {
-    if (m_configCache.get() == null) {
+    if (configCache.get() == null) {
       long start = System.currentTimeMillis();
       this.sync();
-      Tracer.logEvent(APOLLO_CLIENT_NAMESPACE_FIRST_LOAD_SPEND+":"+m_namespace,
+      Tracer.logEvent(APOLLO_CLIENT_NAMESPACE_FIRST_LOAD_SPEND+":"+namespace,
           String.valueOf(System.currentTimeMillis() - start));
     }
-    return transformApolloConfigToProperties(m_configCache.get());
+    return transformApolloConfigToProperties(configCache.get());
   }
 
   @Override
@@ -140,18 +140,18 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
 
   private void schedulePeriodicRefresh() {
     logger.debug("Schedule periodic refresh with interval: {} {}",
-        m_configUtil.getRefreshInterval(), m_configUtil.getRefreshIntervalTimeUnit());
-    m_executorService.scheduleAtFixedRate(
+        configUtil.getRefreshInterval(), configUtil.getRefreshIntervalTimeUnit());
+    executorService.scheduleAtFixedRate(
         new Runnable() {
           @Override
           public void run() {
-            Tracer.logEvent(APOLLO_CONFIGSERVICE, String.format("periodicRefresh: %s", m_namespace));
-            logger.debug("refresh config for namespace: {}", m_namespace);
+            Tracer.logEvent(APOLLO_CONFIGSERVICE, String.format("periodicRefresh: %s", namespace));
+            logger.debug("refresh config for namespace: {}", namespace);
             trySync();
             Tracer.logEvent(APOLLO_CLIENT_VERSION, Apollo.VERSION);
           }
-        }, m_configUtil.getRefreshInterval(), m_configUtil.getRefreshInterval(),
-        m_configUtil.getRefreshIntervalTimeUnit());
+        }, configUtil.getRefreshInterval(), configUtil.getRefreshInterval(),
+        configUtil.getRefreshIntervalTimeUnit());
   }
 
   @Override
@@ -159,14 +159,14 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
     Transaction transaction = Tracer.newTransaction("Apollo.ConfigService", "syncRemoteConfig");
 
     try {
-      ApolloConfig previous = m_configCache.get();
+      ApolloConfig previous = configCache.get();
       ApolloConfig current = loadApolloConfig();
 
       //reference equals means HTTP 304
       if (previous != current) {
         logger.debug("Remote Config refreshed!");
-        m_configCache.set(current);
-        this.fireRepositoryChange(m_appId, m_namespace, this.getConfig());
+        configCache.set(current);
+        this.fireRepositoryChange(appId, namespace, this.getConfig());
       }
 
       if (current != null) {
@@ -190,19 +190,19 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
   }
 
   private ApolloConfig loadApolloConfig() {
-    if (!m_loadConfigRateLimiter.tryAcquire(5, TimeUnit.SECONDS)) {
+    if (!loadConfigRateLimiter.tryAcquire(5, TimeUnit.SECONDS)) {
       //wait at most 5 seconds
       try {
         TimeUnit.SECONDS.sleep(5);
       } catch (InterruptedException e) {
       }
     }
-    String appId = this.m_appId;
-    String cluster = m_configUtil.getCluster();
-    String dataCenter = m_configUtil.getDataCenter();
-    String secret = m_configUtil.getAccessKeySecret(appId);
-    Tracer.logEvent(APOLLO_CLIENT_CONFIGMETA, STRING_JOINER.join(appId, cluster, m_namespace));
-    int maxRetries = m_configNeedForceRefresh.get() ? 2 : 1;
+    String appId = this.appId;
+    String cluster = configUtil.getCluster();
+    String dataCenter = configUtil.getDataCenter();
+    String secret = configUtil.getAccessKeySecret(appId);
+    Tracer.logEvent(APOLLO_CLIENT_CONFIGMETA, STRING_JOINER.join(appId, cluster, namespace));
+    int maxRetries = configNeedForceRefresh.get() ? 2 : 1;
     long onErrorSleepTime = 0; // 0 means no sleep
     Throwable exception = null;
 
@@ -213,25 +213,25 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
       List<ServiceDTO> randomConfigServices = Lists.newLinkedList(configServices);
       Collections.shuffle(randomConfigServices);
       //Access the server which notifies the client first
-      if (m_longPollServiceDto.get() != null) {
-        randomConfigServices.add(0, m_longPollServiceDto.getAndSet(null));
+      if (longPollServiceDto.get() != null) {
+        randomConfigServices.add(0, longPollServiceDto.getAndSet(null));
       }
 
       for (ServiceDTO configService : randomConfigServices) {
         if (onErrorSleepTime > 0) {
           logger.warn(
               "Load config failed, will retry in {} {}. appId: {}, cluster: {}, namespaces: {}",
-              onErrorSleepTime, m_configUtil.getOnErrorRetryIntervalTimeUnit(), appId, cluster, m_namespace);
+              onErrorSleepTime, configUtil.getOnErrorRetryIntervalTimeUnit(), appId, cluster, namespace);
 
           try {
-            m_configUtil.getOnErrorRetryIntervalTimeUnit().sleep(onErrorSleepTime);
+            configUtil.getOnErrorRetryIntervalTimeUnit().sleep(onErrorSleepTime);
           } catch (InterruptedException e) {
             //ignore
           }
         }
 
-        url = assembleQueryConfigUrl(configService.getHomepageUrl(), appId, cluster, m_namespace,
-                dataCenter, m_remoteMessages.get(), m_configCache.get());
+        url = assembleQueryConfigUrl(configService.getHomepageUrl(), appId, cluster, namespace,
+                dataCenter, remoteMessages.get(), configCache.get());
 
         logger.debug("Loading config from {}", url);
 
@@ -245,16 +245,16 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
         transaction.addData("Url", url);
         try {
 
-          HttpResponse<ApolloConfig> response = m_httpClient.doGet(request, ApolloConfig.class);
-          m_configNeedForceRefresh.set(false);
-          m_loadConfigFailSchedulePolicy.success();
+          HttpResponse<ApolloConfig> response = httpClient.doGet(request, ApolloConfig.class);
+          configNeedForceRefresh.set(false);
+          loadConfigFailSchedulePolicy.success();
 
           transaction.addData("StatusCode", response.getStatusCode());
           transaction.setStatus(Transaction.SUCCESS);
 
           if (response.getStatusCode() == 304) {
             logger.debug("Config server responds with 304 HTTP status code.");
-            return m_configCache.get();
+            return configCache.get();
           }
 
           ApolloConfig result = response.getBody();
@@ -263,7 +263,7 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
             ConfigSyncType configSyncType = ConfigSyncType.fromString(result.getConfigSyncType());
 
             if (configSyncType == ConfigSyncType.INCREMENTAL_SYNC) {
-              ApolloConfig previousConfig = m_configCache.get();
+              ApolloConfig previousConfig = configCache.get();
               Map<String, String> previousConfigurations =
                   (previousConfig != null) ? previousConfig.getConfigurations() : null;
               result.setConfigurations(
@@ -277,7 +277,7 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
 
           }
 
-          logger.debug("Loaded config for {}: {}", m_namespace, result);
+          logger.debug("Loaded config for {}: {}", namespace, result);
 
           return result;
         } catch (ApolloConfigStatusCodeException ex) {
@@ -287,10 +287,10 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
             String message = String.format(
                 "Could not find config for namespace - appId: %s, cluster: %s, namespace: %s, " +
                     "please check whether the configs are released in Apollo!",
-                appId, cluster, m_namespace);
+                appId, cluster, namespace);
             statusCodeException = new ApolloConfigStatusCodeException(ex.getStatusCode(),
                 message);
-            Tracer.logEvent(APOLLO_CLIENT_NAMESPACE_NOT_FOUND,m_namespace);
+            Tracer.logEvent(APOLLO_CLIENT_NAMESPACE_NOT_FOUND,namespace);
 
           }
           Tracer.logEvent(APOLLO_CONFIG_EXCEPTION, ExceptionUtil.getDetailMessage(statusCodeException));
@@ -308,14 +308,14 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
         }
 
         // if force refresh, do normal sleep, if normal config load, do exponential sleep
-        onErrorSleepTime = m_configNeedForceRefresh.get() ? m_configUtil.getOnErrorRetryInterval() :
-            m_loadConfigFailSchedulePolicy.fail();
+        onErrorSleepTime = configNeedForceRefresh.get() ? configUtil.getOnErrorRetryInterval() :
+            loadConfigFailSchedulePolicy.fail();
       }
 
     }
     String message = String.format(
         "Load Apollo Config failed - appId: %s, cluster: %s, namespace: %s, url: %s",
-        appId, cluster, m_namespace, url);
+        appId, cluster, namespace, url);
     throw new ApolloConfigException(message, exception);
   }
 
@@ -336,12 +336,12 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
       queryParams.put("dataCenter", queryParamEscaper.escape(dataCenter));
     }
 
-    String localIp = m_configUtil.getLocalIp();
+    String localIp = configUtil.getLocalIp();
     if (!Strings.isNullOrEmpty(localIp)) {
       queryParams.put("ip", queryParamEscaper.escape(localIp));
     }
 
-    String label = m_configUtil.getApolloLabel();
+    String label = configUtil.getApolloLabel();
     if (!Strings.isNullOrEmpty(label)) {
       queryParams.put("label", queryParamEscaper.escape(label));
     }
@@ -362,23 +362,23 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
   }
 
   private void scheduleLongPollingRefresh() {
-    remoteConfigLongPollService.submit(m_appId, m_namespace, this);
+    remoteConfigLongPollService.submit(appId, namespace, this);
   }
 
   public void onLongPollNotified(ServiceDTO longPollNotifiedServiceDto, ApolloNotificationMessages remoteMessages) {
-    m_longPollServiceDto.set(longPollNotifiedServiceDto);
-    m_remoteMessages.set(remoteMessages);
-    m_executorService.submit(new Runnable() {
+    longPollServiceDto.set(longPollNotifiedServiceDto);
+    this.remoteMessages.set(remoteMessages);
+    executorService.submit(new Runnable() {
       @Override
       public void run() {
-        m_configNeedForceRefresh.set(true);
+        configNeedForceRefresh.set(true);
         trySync();
       }
     });
   }
 
   private List<ServiceDTO> getConfigServices() {
-    List<ServiceDTO> services = m_serviceLocator.getConfigServices();
+    List<ServiceDTO> services = serviceLocator.getConfigServices();
     if (services.isEmpty()) {
       throw new ApolloConfigException("No available config service");
     }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/SimpleConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/SimpleConfig.java
@@ -40,11 +40,11 @@ import com.google.common.collect.Maps;
  */
 public class SimpleConfig extends AbstractConfig implements RepositoryChangeListener {
   private static final Logger logger = LoggerFactory.getLogger(SimpleConfig.class);
-  private final String m_appId;
-  private final String m_namespace;
-  private final ConfigRepository m_configRepository;
-  private volatile Properties m_configProperties;
-  private volatile ConfigSourceType m_sourceType = ConfigSourceType.NONE;
+  private final String appId;
+  private final String namespace;
+  private final ConfigRepository configRepository;
+  private volatile Properties configProperties;
+  private volatile ConfigSourceType sourceType = ConfigSourceType.NONE;
 
   /**
    * Constructor.
@@ -67,63 +67,63 @@ public class SimpleConfig extends AbstractConfig implements RepositoryChangeList
     if (appId == null) {
       appId = ApolloInjector.getInstance(ConfigUtil.class).getAppId();
     }
-    m_appId = appId;
-    m_namespace = namespace;
-    m_configRepository = configRepository;
+    this.appId = appId;
+    this.namespace = namespace;
+    this.configRepository = configRepository;
     this.initialize();
   }
 
   private void initialize() {
     try {
-      updateConfig(m_configRepository.getConfig(), m_configRepository.getSourceType());
+      updateConfig(configRepository.getConfig(), configRepository.getSourceType());
     } catch (Throwable ex) {
       Tracer.logError(ex);
-      logger.warn("Init Apollo Simple Config failed - namespace: {}, reason: {}", m_namespace,
+      logger.warn("Init Apollo Simple Config failed - namespace: {}, reason: {}", namespace,
           ExceptionUtil.getDetailMessage(ex));
     } finally {
       //register the change listener no matter config repository is working or not
       //so that whenever config repository is recovered, config could get changed
-      m_configRepository.addChangeListener(this);
+      configRepository.addChangeListener(this);
     }
   }
 
   @Override
   public String getProperty(String key, String defaultValue) {
-    if (m_configProperties == null) {
+    if (configProperties == null) {
       logger.warn("Could not load config from Apollo, always return default value!");
       return defaultValue;
     }
-    return this.m_configProperties.getProperty(key, defaultValue);
+    return this.configProperties.getProperty(key, defaultValue);
   }
 
   @Override
   public Set<String> getPropertyNames() {
-    if (m_configProperties == null) {
+    if (configProperties == null) {
       return Collections.emptySet();
     }
 
-    return m_configProperties.stringPropertyNames();
+    return configProperties.stringPropertyNames();
   }
 
   @Override
   public ConfigSourceType getSourceType() {
-    return m_sourceType;
+    return sourceType;
   }
 
   @Override
   public synchronized void onRepositoryChange(String namespace, Properties newProperties) {
-    this.onRepositoryChange(m_appId, namespace, newProperties);
+    this.onRepositoryChange(appId, namespace, newProperties);
   }
 
   @Override
   public synchronized void onRepositoryChange(String appId, String namespace, Properties newProperties) {
-    if (newProperties.equals(m_configProperties)) {
+    if (newProperties.equals(configProperties)) {
       return;
     }
     Properties newConfigProperties = propertiesFactory.getPropertiesInstance();
     newConfigProperties.putAll(newProperties);
 
-    List<ConfigChange> changes = calcPropertyChanges(appId, namespace, m_configProperties, newConfigProperties);
+    List<ConfigChange> changes = calcPropertyChanges(appId, namespace, configProperties, newConfigProperties);
     Map<String, ConfigChange> changeMap = Maps.uniqueIndex(changes,
         new Function<ConfigChange, String>() {
           @Override
@@ -132,16 +132,16 @@ public class SimpleConfig extends AbstractConfig implements RepositoryChangeList
           }
         });
 
-    updateConfig(newConfigProperties, m_configRepository.getSourceType());
+    updateConfig(newConfigProperties, configRepository.getSourceType());
     clearConfigCache();
 
-    this.fireConfigChange(appId, m_namespace, changeMap);
+    this.fireConfigChange(appId, this.namespace, changeMap);
 
-    Tracer.logEvent(APOLLO_CLIENT_CONFIGCHANGES, m_namespace);
+    Tracer.logEvent(APOLLO_CLIENT_CONFIGCHANGES, this.namespace);
   }
 
   private void updateConfig(Properties newConfigProperties, ConfigSourceType sourceType) {
-    m_configProperties = newConfigProperties;
-    m_sourceType = sourceType;
+    configProperties = newConfigProperties;
+    this.sourceType = sourceType;
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/YamlConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/YamlConfigFile.java
@@ -85,7 +85,7 @@ public class YamlConfigFile extends PlainTextConfigFile implements PropertiesCom
       return ApolloInjector.getInstance(YamlParser.class).yamlToProperties(getContent());
     } catch (Throwable ex) {
       ApolloConfigException exception = new ApolloConfigException(
-          "Parse yaml file content failed for namespace: " + m_namespace, ex);
+          "Parse yaml file content failed for namespace: " + namespace, ex);
       Tracer.logError(exception);
       throw exception;
     }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/model/ConfigChangeEvent.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/model/ConfigChangeEvent.java
@@ -25,9 +25,9 @@ import java.util.Set;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class ConfigChangeEvent {
-  private final String m_appId;
-  private final String m_namespace;
-  private final Map<String, ConfigChange> m_changes;
+  private final String appId;
+  private final String namespace;
+  private final Map<String, ConfigChange> changes;
   /**
    * Constructor.
    * @param namespace the namespace of this change
@@ -35,9 +35,9 @@ public class ConfigChangeEvent {
    */
   public ConfigChangeEvent(String appId, String namespace,
                            Map<String, ConfigChange> changes) {
-    this.m_appId = appId;
-    this.m_namespace = namespace;
-    this.m_changes = changes;
+    this.appId = appId;
+    this.namespace = namespace;
+    this.changes = changes;
   }
 
   /**
@@ -45,7 +45,7 @@ public class ConfigChangeEvent {
    * @return the list of the keys
    */
   public Set<String> changedKeys() {
-    return m_changes.keySet();
+    return changes.keySet();
   }
 
   /**
@@ -63,7 +63,7 @@ public class ConfigChangeEvent {
    * @return the change instance
    */
   public ConfigChange getChange(String key) {
-    return m_changes.get(key);
+    return changes.get(key);
   }
 
   /**
@@ -72,7 +72,7 @@ public class ConfigChangeEvent {
    * @return true if the key is changed, false otherwise.
    */
   public boolean isChanged(String key) {
-    return m_changes.containsKey(key);
+    return changes.containsKey(key);
   }
 
   /**
@@ -80,7 +80,7 @@ public class ConfigChangeEvent {
    * @return the namespace
    */
   public String getAppId() {
-    return m_appId;
+    return appId;
   }
 
   /**
@@ -88,6 +88,6 @@ public class ConfigChangeEvent {
    * @return the namespace
    */
   public String getNamespace() {
-    return m_namespace;
+    return namespace;
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/monitor/api/ApolloClientThreadPoolMonitorApi.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/monitor/api/ApolloClientThreadPoolMonitorApi.java
@@ -30,22 +30,22 @@ public interface ApolloClientThreadPoolMonitorApi {
   Map<String, ApolloThreadPoolInfo> getThreadPoolInfo();
 
   /**
-   * RemoteConfigRepository.m_executorService
+   * RemoteConfigRepository.executorService
    */
   ApolloThreadPoolInfo getRemoteConfigRepositoryThreadPoolInfo();
 
   /**
-   * AbstractConfig.m_executorService
+   * AbstractConfig.executorService
    */
   ApolloThreadPoolInfo getAbstractConfigThreadPoolInfo();
 
   /**
-   * AbstractConfigFile.m_executorService
+   * AbstractConfigFile.executorService
    */
   ApolloThreadPoolInfo getAbstractConfigFileThreadPoolInfo();
 
   /**
-   * AbstractApolloClientMetricsExporter.m_executorService
+   * AbstractApolloClientMetricsExporter.executorService
    */
   ApolloThreadPoolInfo getMetricsExporterThreadPoolInfo();
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/monitor/internal/event/ApolloClientMonitorEventPublisher.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/monitor/internal/event/ApolloClientMonitorEventPublisher.java
@@ -28,10 +28,10 @@ public class ApolloClientMonitorEventPublisher {
 
   private static ApolloClientMonitorContext MONITOR_CONTEXT = ApolloInjector.getInstance(
       ApolloClientMonitorContext.class);
-  private static ConfigUtil m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+  private static ConfigUtil configUtil = ApolloInjector.getInstance(ConfigUtil.class);
 
   public static void publish(ApolloClientMonitorEvent event) {
-    if (m_configUtil.isClientMonitorEnabled()) {
+    if (configUtil.isClientMonitorEnabled()) {
       for (ApolloClientMonitorEventListener listener : MONITOR_CONTEXT.getApolloClientMonitorEventListeners()) {
         if (listener.isSupported(event)) {
           listener.collect(event);
@@ -44,7 +44,7 @@ public class ApolloClientMonitorEventPublisher {
   protected static void reset() {
     MONITOR_CONTEXT = ApolloInjector.getInstance(
         ApolloClientMonitorContext.class);
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
 
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/monitor/internal/exporter/AbstractApolloClientMetricsExporter.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/monitor/internal/exporter/AbstractApolloClientMetricsExporter.java
@@ -33,14 +33,14 @@ import org.slf4j.Logger;
  */
 public abstract class AbstractApolloClientMetricsExporter implements ApolloClientMetricsExporter {
 
-  public static final ScheduledExecutorService m_executorService;
+  public static final ScheduledExecutorService executorService;
   private static final Logger log = DeferredLoggerFactory.getLogger(
       AbstractApolloClientMetricsExporter.class);
   private static final long INITIAL_DELAY = 5L;
   private static final int THREAD_POOL_SIZE = 1;
 
   static {
-    m_executorService = Executors.newScheduledThreadPool(THREAD_POOL_SIZE,
+    executorService = Executors.newScheduledThreadPool(THREAD_POOL_SIZE,
         ApolloThreadFactory.create(ApolloClientMetricsExporter.class.getName(), true));
   }
 
@@ -62,7 +62,7 @@ public abstract class AbstractApolloClientMetricsExporter implements ApolloClien
   protected abstract void doInit();
 
   private void initScheduleMetricsCollectSync(long collectPeriod) {
-    m_executorService.scheduleAtFixedRate(() -> {
+    executorService.scheduleAtFixedRate(() -> {
       try {
         updateMetricsData();
       } catch (Throwable ex) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigFactory.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigFactory.java
@@ -57,15 +57,15 @@ import org.slf4j.LoggerFactory;
 public class DefaultConfigFactory implements ConfigFactory {
 
   private static final Logger logger = LoggerFactory.getLogger(DefaultConfigFactory.class);
-  private final ConfigUtil m_configUtil;
+  private final ConfigUtil configUtil;
 
   public DefaultConfigFactory() {
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
   }
 
   @Override
   public Config create(String namespace) {
-    return this.create(m_configUtil.getAppId(), namespace);
+    return this.create(configUtil.getAppId(), namespace);
   }
 
   @Override
@@ -93,7 +93,7 @@ public class DefaultConfigFactory implements ConfigFactory {
 
   @Override
   public ConfigFile createConfigFile(String namespace, ConfigFileFormat configFileFormat) {
-    return this.createConfigFile(m_configUtil.getAppId(), namespace, configFileFormat);
+    return this.createConfigFile(configUtil.getAppId(), namespace, configFileFormat);
   }
 
   protected Config createRepositoryConfig(String appId, String namespace, ConfigRepository configRepository) {
@@ -122,9 +122,9 @@ public class DefaultConfigFactory implements ConfigFactory {
   }
 
   ConfigRepository createConfigRepository(String appId, String namespace) {
-    if (m_configUtil.isPropertyKubernetesCacheEnabled()) {
+    if (configUtil.isPropertyKubernetesCacheEnabled()) {
       return createConfigMapConfigRepository(appId, namespace);
-    } else if (m_configUtil.isPropertyFileCacheEnabled()) {
+    } else if (configUtil.isPropertyFileCacheEnabled()) {
       return createLocalConfigRepository(appId, namespace);
     }
     return createRemoteConfigRepository(appId, namespace);
@@ -138,7 +138,7 @@ public class DefaultConfigFactory implements ConfigFactory {
    * @return the newly created repository for the given namespace
    */
   LocalFileConfigRepository createLocalConfigRepository(String appId, String namespace) {
-    if (m_configUtil.isInLocalMode()) {
+    if (configUtil.isInLocalMode()) {
       logger.warn(
           "==== Apollo is in local mode! Won't pull configs from remote server for namespace {} ! ====",
           namespace);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryManager.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryManager.java
@@ -26,33 +26,33 @@ import com.google.common.collect.Tables;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class DefaultConfigFactoryManager implements ConfigFactoryManager {
-  private ConfigRegistry m_registry;
+  private ConfigRegistry registry;
 
-  private Table<String, String, ConfigFactory> m_factories = Tables.synchronizedTable(HashBasedTable.create());
+  private Table<String, String, ConfigFactory> factories = Tables.synchronizedTable(HashBasedTable.create());
 
-  private ConfigUtil m_configUtil;
+  private ConfigUtil configUtil;
 
   public DefaultConfigFactoryManager() {
-    m_registry = ApolloInjector.getInstance(ConfigRegistry.class);
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    registry = ApolloInjector.getInstance(ConfigRegistry.class);
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
   }
 
   @Override
   public ConfigFactory getFactory(String namespace) {
-    return getFactory(m_configUtil.getAppId(), namespace);
+    return getFactory(configUtil.getAppId(), namespace);
   }
 
   @Override
   public ConfigFactory getFactory(String appId, String namespace) {
     // step 1: check hacked factory
-    ConfigFactory factory = m_registry.getFactory(appId, namespace);
+    ConfigFactory factory = registry.getFactory(appId, namespace);
 
     if (factory != null) {
       return factory;
     }
 
     // step 2: check cache
-    factory = m_factories.get(appId, namespace);
+    factory = factories.get(appId, namespace);
 
     if (factory != null) {
       return factory;
@@ -68,7 +68,7 @@ public class DefaultConfigFactoryManager implements ConfigFactoryManager {
     // step 4: check default config factory
     factory = ApolloInjector.getInstance(ConfigFactory.class);
 
-    m_factories.put(appId, namespace, factory);
+    factories.put(appId, namespace, factory);
 
     // factory should not be null
     return factory;

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigRegistry.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigRegistry.java
@@ -28,38 +28,38 @@ import org.slf4j.LoggerFactory;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class DefaultConfigRegistry implements ConfigRegistry {
-  private static final Logger s_logger = LoggerFactory.getLogger(DefaultConfigRegistry.class);
+  private static final Logger logger = LoggerFactory.getLogger(DefaultConfigRegistry.class);
 
-  private ConfigUtil m_configUtil;
+  private ConfigUtil configUtil;
 
-  private Table<String, String, ConfigFactory> m_instances = Tables.synchronizedTable(
+  private Table<String, String, ConfigFactory> instances = Tables.synchronizedTable(
       HashBasedTable.create());
 
   public DefaultConfigRegistry() {
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
   }
 
   @Override
   public void register(String namespace, ConfigFactory factory) {
-    register(m_configUtil.getAppId(), namespace, factory);
+    register(configUtil.getAppId(), namespace, factory);
   }
 
   @Override
   public void register(String appId, String namespace, ConfigFactory factory) {
-    if (m_instances.contains(appId, namespace)) {
-      s_logger.warn("ConfigFactory({}-{}) is overridden by {}!", appId, namespace, factory.getClass());
+    if (instances.contains(appId, namespace)) {
+      logger.warn("ConfigFactory({}-{}) is overridden by {}!", appId, namespace, factory.getClass());
     }
 
-    m_instances.put(appId, namespace, factory);
+    instances.put(appId, namespace, factory);
   }
 
   @Override
   public ConfigFactory getFactory(String namespace) {
-    return getFactory(m_configUtil.getAppId(), namespace);
+    return getFactory(configUtil.getAppId(), namespace);
   }
 
   @Override
   public ConfigFactory getFactory(String appId, String namespace) {
-    return m_instances.get(appId, namespace);
+    return instances.get(appId, namespace);
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/SpringInjector.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/util/SpringInjector.java
@@ -27,15 +27,15 @@ import com.google.inject.Injector;
 import com.google.inject.Singleton;
 
 public class SpringInjector {
-  private static volatile Injector s_injector;
+  private static volatile Injector injector;
   private static final Object lock = new Object();
 
   private static Injector getInjector() {
-    if (s_injector == null) {
+    if (injector == null) {
       synchronized (lock) {
-        if (s_injector == null) {
+        if (injector == null) {
           try {
-            s_injector = Guice.createInjector(new SpringModule());
+            injector = Guice.createInjector(new SpringModule());
           } catch (Throwable ex) {
             ApolloConfigException exception = new ApolloConfigException("Unable to initialize Apollo Spring Injector!", ex);
             Tracer.logError(exception);
@@ -45,7 +45,7 @@ public class SpringInjector {
       }
     }
 
-    return s_injector;
+    return injector;
   }
 
   public static <T> T getInstance(Class<T> clazz) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/factory/DefaultPropertiesFactory.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/factory/DefaultPropertiesFactory.java
@@ -28,15 +28,15 @@ import java.util.Properties;
  */
 public class DefaultPropertiesFactory implements PropertiesFactory {
 
-  private ConfigUtil m_configUtil;
+  private ConfigUtil configUtil;
 
   public DefaultPropertiesFactory() {
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
   }
 
   @Override
   public Properties getPropertiesInstance() {
-    if (m_configUtil.isPropertiesOrderEnabled()) {
+    if (configUtil.isPropertiesOrderEnabled()) {
       return new OrderedProperties();
     } else {
       return new Properties();

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/DefaultHttpClient.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/DefaultHttpClient.java
@@ -36,14 +36,14 @@ import java.util.Map;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class DefaultHttpClient implements HttpClient {
-  private ConfigUtil m_configUtil;
+  private ConfigUtil configUtil;
   private static final Gson GSON = new Gson();
 
   /**
    * Constructor.
    */
   public DefaultHttpClient() {
-    m_configUtil = ApolloInjector.getInstance(ConfigUtil.class);
+    configUtil = ApolloInjector.getInstance(ConfigUtil.class);
   }
 
   /**
@@ -105,12 +105,12 @@ public class DefaultHttpClient implements HttpClient {
 
       int connectTimeout = httpRequest.getConnectTimeout();
       if (connectTimeout < 0) {
-        connectTimeout = m_configUtil.getConnectTimeout();
+        connectTimeout = configUtil.getConnectTimeout();
       }
 
       int readTimeout = httpRequest.getReadTimeout();
       if (readTimeout < 0) {
-        readTimeout = m_configUtil.getReadTimeout();
+        readTimeout = configUtil.getReadTimeout();
       }
 
       conn.setConnectTimeout(connectTimeout);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpRequest.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpRequest.java
@@ -22,23 +22,23 @@ import java.util.Map;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class HttpRequest {
-  private final String m_url;
+  private final String url;
   private Map<String, String> headers;
-  private int m_connectTimeout;
-  private int m_readTimeout;
+  private int connectTimeout;
+  private int readTimeout;
 
   /**
    * Create the request for the url.
    * @param url the url
    */
   public HttpRequest(String url) {
-    this.m_url = url;
-    m_connectTimeout = -1;
-    m_readTimeout = -1;
+    this.url = url;
+    connectTimeout = -1;
+    readTimeout = -1;
   }
 
   public String getUrl() {
-    return m_url;
+    return url;
   }
 
   public Map<String, String> getHeaders() {
@@ -50,18 +50,18 @@ public class HttpRequest {
   }
 
   public int getConnectTimeout() {
-    return m_connectTimeout;
+    return connectTimeout;
   }
 
   public void setConnectTimeout(int connectTimeout) {
-    this.m_connectTimeout = connectTimeout;
+    this.connectTimeout = connectTimeout;
   }
 
   public int getReadTimeout() {
-    return m_readTimeout;
+    return readTimeout;
   }
 
   public void setReadTimeout(int readTimeout) {
-    this.m_readTimeout = readTimeout;
+    this.readTimeout = readTimeout;
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpResponse.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpResponse.java
@@ -20,19 +20,19 @@ package com.ctrip.framework.apollo.util.http;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class HttpResponse<T> {
-  private final int m_statusCode;
-  private final T m_body;
+  private final int statusCode;
+  private final T body;
 
   public HttpResponse(int statusCode, T body) {
-    this.m_statusCode = statusCode;
-    this.m_body = body;
+    this.statusCode = statusCode;
+    this.body = body;
   }
 
   public int getStatusCode() {
-    return m_statusCode;
+    return statusCode;
   }
 
   public T getBody() {
-    return m_body;
+    return body;
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpUtil.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/http/HttpUtil.java
@@ -27,13 +27,13 @@ import java.lang.reflect.Type;
 @Deprecated
 public class HttpUtil implements HttpClient {
 
-  private HttpClient m_httpClient;
+  private HttpClient httpClient;
 
   /**
    * Constructor.
    */
   public HttpUtil() {
-    m_httpClient = new DefaultHttpClient();
+    httpClient = new DefaultHttpClient();
   }
 
   /**
@@ -46,7 +46,7 @@ public class HttpUtil implements HttpClient {
    */
   @Override
   public <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Class<T> responseType) {
-    return m_httpClient.doGet(httpRequest, responseType);
+    return httpClient.doGet(httpRequest, responseType);
   }
 
   /**
@@ -59,6 +59,6 @@ public class HttpUtil implements HttpClient {
    */
   @Override
   public <T> HttpResponse<T> doGet(HttpRequest httpRequest, final Type responseType) {
-    return m_httpClient.doGet(httpRequest, responseType);
+    return httpClient.doGet(httpRequest, responseType);
   }
 }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/ConfigServiceTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/ConfigServiceTest.java
@@ -160,12 +160,12 @@ public class ConfigServiceTest {
   }
 
   private static class MockConfig extends AbstractConfig {
-    private final String m_appId;
-    private final String m_namespace;
+    private final String appId;
+    private final String namespace;
 
     public MockConfig(String appId, String namespace) {
-      m_appId = appId;
-      m_namespace = namespace;
+      this.appId = appId;
+      this.namespace = namespace;
     }
 
     @Override
@@ -174,7 +174,7 @@ public class ConfigServiceTest {
         return null;
       }
 
-      return m_appId + ConfigConsts.CLUSTER_NAMESPACE_SEPARATOR + m_namespace + ":" + key;
+      return appId + ConfigConsts.CLUSTER_NAMESPACE_SEPARATOR + namespace + ":" + key;
     }
 
     @Override
@@ -189,26 +189,26 @@ public class ConfigServiceTest {
   }
 
   private static class MockConfigFile implements ConfigFile {
-    private ConfigFileFormat m_configFileFormat;
-    private String m_appId;
-    private String m_namespace;
+    private ConfigFileFormat configFileFormat;
+    private String appId;
+    private String namespace;
 
     public MockConfigFile(String namespace,
                           ConfigFileFormat configFileFormat) {
-      m_namespace = namespace;
-      m_configFileFormat = configFileFormat;
+      this.namespace = namespace;
+      this.configFileFormat = configFileFormat;
     }
 
     public MockConfigFile(String appId, String namespace,
                           ConfigFileFormat configFileFormat) {
-      m_appId = appId;
-      m_namespace = namespace;
-      m_configFileFormat = configFileFormat;
+      this.appId = appId;
+      this.namespace = namespace;
+      this.configFileFormat = configFileFormat;
     }
 
     @Override
     public String getContent() {
-      return m_namespace + ":" + m_configFileFormat.getValue();
+      return namespace + ":" + configFileFormat.getValue();
     }
 
     @Override
@@ -218,17 +218,17 @@ public class ConfigServiceTest {
 
     @Override
     public String getAppId() {
-      return m_appId;
+      return appId;
     }
 
     @Override
     public String getNamespace() {
-      return m_namespace;
+      return namespace;
     }
 
     @Override
     public ConfigFileFormat getConfigFileFormat() {
-      return m_configFileFormat;
+      return configFileFormat;
     }
 
     @Override
@@ -270,22 +270,22 @@ public class ConfigServiceTest {
   }
 
   private static class MockPropertiesCompatibleConfigFile implements PropertiesCompatibleConfigFile {
-    private final String m_appId;
-    private final String m_namespace;
-    private final ConfigFileFormat m_configFileFormat;
+    private final String appId;
+    private final String namespace;
+    private final ConfigFileFormat configFileFormat;
 
     public MockPropertiesCompatibleConfigFile(String appId, String namespace,
         ConfigFileFormat configFileFormat) {
-      m_appId = appId;
-      m_namespace = namespace;
-      m_configFileFormat = configFileFormat;
+      this.appId = appId;
+      this.namespace = namespace;
+      this.configFileFormat = configFileFormat;
     }
 
     @Override
     public Properties asProperties() {
       Properties properties = new Properties();
       // echo the appId so it is observable through the resulting Config
-      properties.setProperty("appId", m_appId);
+      properties.setProperty("appId", appId);
       return properties;
     }
 
@@ -301,17 +301,17 @@ public class ConfigServiceTest {
 
     @Override
     public String getAppId() {
-      return m_appId;
+      return appId;
     }
 
     @Override
     public String getNamespace() {
-      return m_namespace;
+      return namespace;
     }
 
     @Override
     public ConfigFileFormat getConfigFileFormat() {
-      return m_configFileFormat;
+      return configFileFormat;
     }
 
     @Override

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigLongPollServiceTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigLongPollServiceTest.java
@@ -96,7 +96,7 @@ public class RemoteConfigLongPollServiceTest {
     remoteConfigLongPollService = new RemoteConfigLongPollService();
 
     responseType =
-        (Type) ReflectionTestUtils.getField(remoteConfigLongPollService, "m_responseType");
+        (Type) ReflectionTestUtils.getField(remoteConfigLongPollService, "responseType");
 
 
   }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryTest.java
@@ -97,7 +97,7 @@ public class DefaultConfigFactoryTest {
     LocalFileConfigRepository localFileConfigRepository =
         defaultConfigFactory.createLocalConfigRepository(someAppId, someNamespace);
 
-    assertNull(ReflectionTestUtils.getField(localFileConfigRepository, "m_upstream"));
+    assertNull(ReflectionTestUtils.getField(localFileConfigRepository, "upstream"));
   }
 
   @Test

--- a/apollo-compat-tests/apollo-api-compat-it/src/test/java/com/ctrip/framework/apollo/compat/api/ApolloApiCompatibilityTest.java
+++ b/apollo-compat-tests/apollo-api-compat-it/src/test/java/com/ctrip/framework/apollo/compat/api/ApolloApiCompatibilityTest.java
@@ -184,12 +184,12 @@ public class ApolloApiCompatibilityTest {
   }
 
   private static void clearApolloClientCaches() throws Exception {
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configs");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configLocks");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFiles");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFileLocks");
-    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "m_factories");
-    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "m_instances");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configs");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configLocks");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFiles");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFileLocks");
+    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "factories");
+    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "instances");
   }
 
   private static void clearField(Object target, String fieldName) throws Exception {

--- a/apollo-compat-tests/apollo-spring-boot-compat-it/src/test/java/com/ctrip/framework/apollo/compat/springboot/ApolloSpringBootCompatibilityTest.java
+++ b/apollo-compat-tests/apollo-spring-boot-compat-it/src/test/java/com/ctrip/framework/apollo/compat/springboot/ApolloSpringBootCompatibilityTest.java
@@ -424,12 +424,12 @@ public class ApolloSpringBootCompatibilityTest {
   }
 
   private static void clearApolloClientCaches() throws Exception {
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configs");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configLocks");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFiles");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFileLocks");
-    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "m_factories");
-    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "m_instances");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configs");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configLocks");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFiles");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFileLocks");
+    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "factories");
+    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "instances");
   }
 
   private static void clearField(Object target, String fieldName) throws Exception {

--- a/apollo-compat-tests/apollo-spring-compat-it/src/test/java/com/ctrip/framework/apollo/compat/spring/SpringCompatibilityTestSupport.java
+++ b/apollo-compat-tests/apollo-spring-compat-it/src/test/java/com/ctrip/framework/apollo/compat/spring/SpringCompatibilityTestSupport.java
@@ -100,12 +100,12 @@ final class SpringCompatibilityTestSupport {
   }
 
   private static void clearApolloClientCaches() throws Exception {
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configs");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configLocks");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFiles");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFileLocks");
-    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "m_factories");
-    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "m_instances");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configs");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configLocks");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFiles");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFileLocks");
+    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "factories");
+    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "instances");
   }
 
   private static void clearField(Object target, String fieldName) throws Exception {

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/Foundation.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/Foundation.java
@@ -30,7 +30,7 @@ public abstract class Foundation {
   private static final Logger logger = LoggerFactory.getLogger(Foundation.class);
   private static final Object LOCK = new Object();
 
-  private static volatile ProviderManager s_manager;
+  private static volatile ProviderManager manager;
 
   // Encourage early initialization and fail early if it happens.
   static {
@@ -39,21 +39,21 @@ public abstract class Foundation {
 
   private static ProviderManager getManager() {
     try {
-      if (s_manager == null) {
+      if (manager == null) {
         // Double locking to make sure only one thread initializes ProviderManager.
         synchronized (LOCK) {
-          if (s_manager == null) {
-            s_manager = ServiceBootstrap.loadPrimary(ProviderManager.class);
-            s_manager.initialize();
+          if (manager == null) {
+            manager = ServiceBootstrap.loadPrimary(ProviderManager.class);
+            manager.initialize();
           }
         }
       }
 
-      return s_manager;
+      return manager;
     } catch (Throwable ex) {
-      s_manager = new NullProviderManager();
+      manager = new NullProviderManager();
       logger.error("Initialize ProviderManager failed.", ex);
-      return s_manager;
+      return manager;
     }
   }
 

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/DefaultProviderManager.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/DefaultProviderManager.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 public class DefaultProviderManager implements ProviderManager {
   private static final Logger logger = LoggerFactory.getLogger(DefaultProviderManager.class);
-  private Map<Class<? extends Provider>, Provider> m_providers = new LinkedHashMap<>();
+  private Map<Class<? extends Provider>, Provider> providers = new LinkedHashMap<>();
 
   @Override
   public void initialize() {
@@ -51,13 +51,13 @@ public class DefaultProviderManager implements ProviderManager {
   }
 
   public synchronized void register(Provider provider) {
-    m_providers.put(provider.getType(), provider);
+    providers.put(provider.getType(), provider);
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public <T extends Provider> T provider(Class<T> clazz) {
-    Provider provider = m_providers.get(clazz);
+    Provider provider = providers.get(clazz);
 
     if (provider != null) {
       return (T) provider;
@@ -69,7 +69,7 @@ public class DefaultProviderManager implements ProviderManager {
 
   @Override
   public String getProperty(String name, String defaultValue) {
-    for (Provider provider : m_providers.values()) {
+    for (Provider provider : providers.values()) {
       String value = provider.getProperty(name, null);
 
       if (value != null) {
@@ -83,8 +83,8 @@ public class DefaultProviderManager implements ProviderManager {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder(512);
-    if (null != m_providers) {
-      for (Map.Entry<Class<? extends Provider>, Provider> entry : m_providers.entrySet()) {
+    if (null != providers) {
+      for (Map.Entry<Class<? extends Provider>, Provider> entry : providers.entrySet()) {
         sb.append(entry.getValue()).append("\n");
       }
     }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/NetworkInterfaceManager.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/NetworkInterfaceManager.java
@@ -30,9 +30,9 @@ import java.util.List;
 public enum NetworkInterfaceManager {
   INSTANCE;
 
-  private InetAddress m_local;
+  private InetAddress local;
 
-  private InetAddress m_localHost;
+  private InetAddress localHost;
 
   NetworkInterfaceManager() {
     load();
@@ -78,17 +78,17 @@ public enum NetworkInterfaceManager {
   }
 
   public String getLocalHostAddress() {
-    return m_local.getHostAddress();
+    return local.getHostAddress();
   }
 
   public String getLocalHostName() {
     try {
-      if (null == m_localHost) {
-        m_localHost = InetAddress.getLocalHost();
+      if (null == localHost) {
+        localHost = InetAddress.getLocalHost();
       }
-      return m_localHost.getHostName();
+      return localHost.getHostName();
     } catch (UnknownHostException e) {
-      return m_local.getHostName();
+      return local.getHostName();
     }
   }
 
@@ -107,7 +107,7 @@ public enum NetworkInterfaceManager {
 
     if (ip != null) {
       try {
-        m_local = InetAddress.getByName(ip);
+        local = InetAddress.getByName(ip);
         return;
       } catch (Exception e) {
         System.err.println(e);
@@ -118,14 +118,14 @@ public enum NetworkInterfaceManager {
     try {
       Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
       if (interfaces == null) {
-        m_local = InetAddress.getLoopbackAddress();
+        local = InetAddress.getLoopbackAddress();
         return;
       }
       List<NetworkInterface> nis = Collections.list(interfaces);
       //sort the network interfaces according to the index asc
       nis.sort(Comparator.comparingInt(NetworkInterface::getIndex));
       List<InetAddress> addresses = new ArrayList<>();
-      InetAddress local = null;
+      InetAddress resolvedAddress = null;
 
       try {
         for (NetworkInterface ni : nis) {
@@ -133,18 +133,18 @@ public enum NetworkInterfaceManager {
             addresses.addAll(Collections.list(ni.getInetAddresses()));
           }
         }
-        local = findValidateIp(addresses);
+        resolvedAddress = findValidateIp(addresses);
       } catch (Exception e) {
         // ignore
       }
-      if (local != null) {
-        m_local = local;
+      if (resolvedAddress != null) {
+        local = resolvedAddress;
         return;
       }
     } catch (SocketException e) {
       // ignore it
     }
 
-    m_local = InetAddress.getLoopbackAddress();
+    local = InetAddress.getLoopbackAddress();
   }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
@@ -35,10 +35,10 @@ public class DefaultApplicationProvider implements ApplicationProvider {
   private static final Logger logger = DeferredLoggerFactory
       .getLogger(DefaultApplicationProvider.class);
   public static final String APP_PROPERTIES_CLASSPATH = "/META-INF/app.properties";
-  private Properties m_appProperties = new Properties();
+  private Properties appProperties = new Properties();
 
-  private String m_appId;
-  private String m_appLabel;
+  private String appId;
+  private String appLabel;
   private String accessKeySecret;
 
   @Override
@@ -61,7 +61,7 @@ public class DefaultApplicationProvider implements ApplicationProvider {
     try {
       if (in != null) {
         try {
-          m_appProperties
+          appProperties
               .load(new InputStreamReader(new BOMInputStream(in), StandardCharsets.UTF_8));
         } finally {
           in.close();
@@ -78,12 +78,12 @@ public class DefaultApplicationProvider implements ApplicationProvider {
 
   @Override
   public String getAppId() {
-    return m_appId;
+    return appId;
   }
 
   @Override
   public String getApolloLabel() {
-    return m_appLabel;
+    return appLabel;
   }
 
   @Override
@@ -93,7 +93,7 @@ public class DefaultApplicationProvider implements ApplicationProvider {
 
   @Override
   public boolean isAppIdSet() {
-    return !Utils.isBlank(m_appId);
+    return !Utils.isBlank(appId);
   }
 
   @Override
@@ -108,7 +108,7 @@ public class DefaultApplicationProvider implements ApplicationProvider {
       return val == null ? defaultValue : val;
     }
 
-    String val = m_appProperties.getProperty(name, defaultValue);
+    String val = appProperties.getProperty(name, defaultValue);
     return val == null ? defaultValue : val;
   }
 
@@ -119,7 +119,7 @@ public class DefaultApplicationProvider implements ApplicationProvider {
 
   @Override
   public String getAccessKeySecret(String appId){
-    if (Objects.equals(appId, m_appId)) {
+    if (Objects.equals(appId, this.appId)) {
       return getAccessKeySecret();
     }
     return System.getProperty("apollo.accesskey." + appId + ".secret", null);
@@ -127,62 +127,62 @@ public class DefaultApplicationProvider implements ApplicationProvider {
 
   private void initAppId() {
     // 1. Get app.id from System Property
-    m_appId = System.getProperty(ApolloClientSystemConsts.APP_ID);
-    if (!Utils.isBlank(m_appId)) {
-      m_appId = m_appId.trim();
-      logger.info("App ID is set to {} by app.id property from System Property", m_appId);
+    appId = System.getProperty(ApolloClientSystemConsts.APP_ID);
+    if (!Utils.isBlank(appId)) {
+      appId = appId.trim();
+      logger.info("App ID is set to {} by app.id property from System Property", appId);
       return;
     }
 
     //2. Try to get app id from OS environment variable
-    m_appId = System.getenv(ApolloClientSystemConsts.APP_ID_ENVIRONMENT_VARIABLES);
-    if (!Utils.isBlank(m_appId)) {
-      m_appId = m_appId.trim();
-      logger.info("App ID is set to {} by APP_ID property from OS environment variable", m_appId);
+    appId = System.getenv(ApolloClientSystemConsts.APP_ID_ENVIRONMENT_VARIABLES);
+    if (!Utils.isBlank(appId)) {
+      appId = appId.trim();
+      logger.info("App ID is set to {} by APP_ID property from OS environment variable", appId);
       return;
     }
 
     // 3. Try to get app id from app.properties.
-    m_appId = m_appProperties.getProperty(ApolloClientSystemConsts.APP_ID);
-    if (!Utils.isBlank(m_appId)) {
-      m_appId = m_appId.trim();
-      logger.info("App ID is set to {} by app.id property from {}", m_appId,
+    appId = appProperties.getProperty(ApolloClientSystemConsts.APP_ID);
+    if (!Utils.isBlank(appId)) {
+      appId = appId.trim();
+      logger.info("App ID is set to {} by app.id property from {}", appId,
           APP_PROPERTIES_CLASSPATH);
       return;
     }
 
-    m_appId = null;
+    appId = null;
     logger.warn("app.id is not available from System Property and {}. It is set to null",
         APP_PROPERTIES_CLASSPATH);
   }
 
   private void initAppLabel() {
     // 1. Get app.label from System Property
-    m_appLabel = System.getProperty(ApolloClientSystemConsts.APOLLO_LABEL);
-    if (!Utils.isBlank(m_appLabel)) {
-      m_appLabel = m_appLabel.trim();
-      logger.info("App Label is set to {} by app.label property from System Property", m_appLabel);
+    appLabel = System.getProperty(ApolloClientSystemConsts.APOLLO_LABEL);
+    if (!Utils.isBlank(appLabel)) {
+      appLabel = appLabel.trim();
+      logger.info("App Label is set to {} by app.label property from System Property", appLabel);
       return;
     }
 
     //2. Try to get app label from OS environment variable
-    m_appLabel = System.getenv(ApolloClientSystemConsts.APOLLO_LABEL_ENVIRONMENT_VARIABLES);
-    if (!Utils.isBlank(m_appLabel)) {
-      m_appLabel = m_appLabel.trim();
-      logger.info("App Label is set to {} by APP_LABEL property from OS environment variable", m_appLabel);
+    appLabel = System.getenv(ApolloClientSystemConsts.APOLLO_LABEL_ENVIRONMENT_VARIABLES);
+    if (!Utils.isBlank(appLabel)) {
+      appLabel = appLabel.trim();
+      logger.info("App Label is set to {} by APP_LABEL property from OS environment variable", appLabel);
       return;
     }
 
     // 3. Try to get app label from app.properties.
-    m_appLabel = m_appProperties.getProperty(ApolloClientSystemConsts.APOLLO_LABEL);
-    if (!Utils.isBlank(m_appLabel)) {
-      m_appLabel = m_appLabel.trim();
-      logger.info("App Label is set to {} by app.label property from {}", m_appLabel,
+    appLabel = appProperties.getProperty(ApolloClientSystemConsts.APOLLO_LABEL);
+    if (!Utils.isBlank(appLabel)) {
+      appLabel = appLabel.trim();
+      logger.info("App Label is set to {} by app.label property from {}", appLabel,
           APP_PROPERTIES_CLASSPATH);
       return;
     }
 
-    m_appLabel = null;
+    appLabel = null;
     logger.warn("app.label is not available from System Property and {}. It is set to null",
         APP_PROPERTIES_CLASSPATH);
   }
@@ -207,7 +207,7 @@ public class DefaultApplicationProvider implements ApplicationProvider {
     }
 
     // 3. Try to get ACCESS KEY SECRET from app.properties.
-    accessKeySecret = m_appProperties.getProperty(ApolloClientSystemConsts.APOLLO_ACCESS_KEY_SECRET);
+    accessKeySecret = appProperties.getProperty(ApolloClientSystemConsts.APOLLO_ACCESS_KEY_SECRET);
     if (!Utils.isBlank(accessKeySecret)) {
       accessKeySecret = accessKeySecret.trim();
       logger.info("ACCESS KEY SECRET is set by apollo.access-key.secret property from {}",
@@ -252,7 +252,7 @@ public class DefaultApplicationProvider implements ApplicationProvider {
     }
 
     // 3. Try to get ACCESS KEY SECRET from app.properties.
-    accessKeySecret = m_appProperties
+    accessKeySecret = appProperties
         .getProperty(ApolloClientSystemConsts.DEPRECATED_APOLLO_ACCESS_KEY_SECRET);
     if (!Utils.isBlank(accessKeySecret)) {
       accessKeySecret = accessKeySecret.trim();
@@ -268,7 +268,7 @@ public class DefaultApplicationProvider implements ApplicationProvider {
 
   @Override
   public String toString() {
-    return "appId [" + getAppId() + "] properties: " + m_appProperties
+    return "appId [" + getAppId() + "] properties: " + appProperties
         + " (DefaultApplicationProvider)";
   }
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultServerProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultServerProvider.java
@@ -55,10 +55,10 @@ public class DefaultServerProvider implements ServerProvider {
 
   static final String DEFAULT_SERVER_PROPERTIES_PATH_ON_LINUX = "/opt/settings/server.properties";
   static final String DEFAULT_SERVER_PROPERTIES_PATH_ON_WINDOWS = "C:/opt/settings/server.properties";
-  private String m_env;
-  private String m_dc;
+  private String env;
+  private String dc;
 
-  private final Properties m_serverProperties = new Properties();
+  private final Properties serverProperties = new Properties();
 
   String getServerPropertiesPath() {
     final String serverPropertiesPath = getCustomizedServerPropertiesPath();
@@ -112,7 +112,7 @@ public class DefaultServerProvider implements ServerProvider {
     try {
       if (in != null) {
         try {
-          m_serverProperties
+          serverProperties
               .load(new InputStreamReader(new BOMInputStream(in), StandardCharsets.UTF_8));
         } finally {
           in.close();
@@ -128,22 +128,22 @@ public class DefaultServerProvider implements ServerProvider {
 
   @Override
   public String getDataCenter() {
-    return m_dc;
+    return dc;
   }
 
   @Override
   public boolean isDataCenterSet() {
-    return m_dc != null;
+    return dc != null;
   }
 
   @Override
   public String getEnvType() {
-    return m_env;
+    return env;
   }
 
   @Override
   public boolean isEnvTypeSet() {
-    return m_env != null;
+    return env != null;
   }
 
   @Override
@@ -156,7 +156,7 @@ public class DefaultServerProvider implements ServerProvider {
       String val = getDataCenter();
       return val == null ? defaultValue : val;
     }
-    String val = m_serverProperties.getProperty(name, defaultValue);
+    String val = serverProperties.getProperty(name, defaultValue);
     return val == null ? defaultValue : val.trim();
   }
 
@@ -167,62 +167,62 @@ public class DefaultServerProvider implements ServerProvider {
 
   private void initEnvType() {
     // 1. Try to get environment from JVM system property
-    m_env = System.getProperty("env");
-    if (!Utils.isBlank(m_env)) {
-      m_env = m_env.trim();
-      logger.info("Environment is set to [{}] by JVM system property 'env'.", m_env);
+    env = System.getProperty("env");
+    if (!Utils.isBlank(env)) {
+      env = env.trim();
+      logger.info("Environment is set to [{}] by JVM system property 'env'.", env);
       return;
     }
 
     // 2. Try to get environment from OS environment variable
-    m_env = System.getenv("ENV");
-    if (!Utils.isBlank(m_env)) {
-      m_env = m_env.trim();
-      logger.info("Environment is set to [{}] by OS env variable 'ENV'.", m_env);
+    env = System.getenv("ENV");
+    if (!Utils.isBlank(env)) {
+      env = env.trim();
+      logger.info("Environment is set to [{}] by OS env variable 'ENV'.", env);
       return;
     }
 
     // 3. Try to get environment from file "server.properties"
-    m_env = m_serverProperties.getProperty("env");
-    if (!Utils.isBlank(m_env)) {
-      m_env = m_env.trim();
-      logger.info("Environment is set to [{}] by property 'env' in server.properties.", m_env);
+    env = serverProperties.getProperty("env");
+    if (!Utils.isBlank(env)) {
+      env = env.trim();
+      logger.info("Environment is set to [{}] by property 'env' in server.properties.", env);
       return;
     }
 
     // 4. Set environment to null.
-    m_env = null;
+    env = null;
     logger.info(
         "Environment is set to null. Because it is not available in either (1) JVM system property 'env', (2) OS env variable 'ENV' nor (3) property 'env' from the properties InputStream.");
   }
 
   private void initDataCenter() {
     // 1. Try to get environment from JVM system property
-    m_dc = System.getProperty("idc");
-    if (!Utils.isBlank(m_dc)) {
-      m_dc = m_dc.trim();
-      logger.info("Data Center is set to [{}] by JVM system property 'idc'.", m_dc);
+    dc = System.getProperty("idc");
+    if (!Utils.isBlank(dc)) {
+      dc = dc.trim();
+      logger.info("Data Center is set to [{}] by JVM system property 'idc'.", dc);
       return;
     }
 
     // 2. Try to get idc from OS environment variable
-    m_dc = System.getenv("IDC");
-    if (!Utils.isBlank(m_dc)) {
-      m_dc = m_dc.trim();
-      logger.info("Data Center is set to [{}] by OS env variable 'IDC'.", m_dc);
+    dc = System.getenv("IDC");
+    if (!Utils.isBlank(dc)) {
+      dc = dc.trim();
+      logger.info("Data Center is set to [{}] by OS env variable 'IDC'.", dc);
       return;
     }
 
     // 3. Try to get idc from from file "server.properties"
-    m_dc = m_serverProperties.getProperty("idc");
-    if (!Utils.isBlank(m_dc)) {
-      m_dc = m_dc.trim();
-      logger.info("Data Center is set to [{}] by property 'idc' in server.properties.", m_dc);
+    dc = serverProperties.getProperty("idc");
+    if (!Utils.isBlank(dc)) {
+      dc = dc.trim();
+      logger.info("Data Center is set to [{}] by property 'idc' in server.properties.", dc);
       return;
     }
 
     // 4. Set Data Center to null.
-    m_dc = null;
+    dc = null;
     logger.debug(
         "Data Center is set to null. Because it is not available in either (1) JVM system property 'idc', (2) OS env variable 'IDC' nor (3) property 'idc' from the properties InputStream.");
   }
@@ -230,7 +230,7 @@ public class DefaultServerProvider implements ServerProvider {
   @Override
   public String toString() {
     return "environment [" + getEnvType() + "] data center [" + getDataCenter() + "] properties: "
-        + m_serverProperties
+        + serverProperties
         + " (DefaultServerProvider)";
   }
 }

--- a/apollo-core/src/test/java/com/ctrip/framework/apollo/tracer/internals/MockMessageProducerManager.java
+++ b/apollo-core/src/test/java/com/ctrip/framework/apollo/tracer/internals/MockMessageProducerManager.java
@@ -23,14 +23,14 @@ import com.ctrip.framework.apollo.tracer.spi.MessageProducerManager;
  * @author Jason Song(song_s@ctrip.com)
  */
 public class MockMessageProducerManager implements MessageProducerManager {
-  private static MessageProducer s_producer;
+  private static MessageProducer producer;
 
   @Override
   public MessageProducer getProducer() {
-    return s_producer;
+    return producer;
   }
 
-  public static void setProducer(MessageProducer producer) {
-    s_producer = producer;
+  public static void setProducer(MessageProducer newProducer) {
+    producer = newProducer;
   }
 }

--- a/apollo-mockserver/src/main/java/com/ctrip/framework/apollo/mockserver/ApolloTestingServer.java
+++ b/apollo-mockserver/src/main/java/com/ctrip/framework/apollo/mockserver/ApolloTestingServer.java
@@ -313,16 +313,16 @@ public class ApolloTestingServer implements AutoCloseable {
     private static void prepareLongPollingService() throws Exception {
         RemoteConfigLongPollService longPollService =
             ApolloInjector.getInstance(RemoteConfigLongPollService.class);
-        AtomicBoolean stopped = (AtomicBoolean) getLongPollField(longPollService, "m_longPollingStopped");
+        AtomicBoolean stopped = (AtomicBoolean) getLongPollField(longPollService, "longPollingStopped");
         stopped.set(false);
     }
 
     @SuppressWarnings("unchecked")
     private static void clearLongPollingState(RemoteConfigLongPollService longPollService) throws Exception {
-        ((Map<String, Boolean>) getLongPollField(longPollService, "m_longPollStarted")).clear();
-        ((Map<String, ?>) getLongPollField(longPollService, "m_longPollNamespaces")).clear();
-        ((Table<String, String, Long>) getLongPollField(longPollService, "m_notifications")).clear();
-        ((Map<String, ?>) getLongPollField(longPollService, "m_remoteNotificationMessages")).clear();
+        ((Map<String, Boolean>) getLongPollField(longPollService, "longPollStarted")).clear();
+        ((Map<String, ?>) getLongPollField(longPollService, "longPollNamespaces")).clear();
+        ((Table<String, String, Long>) getLongPollField(longPollService, "notifications")).clear();
+        ((Map<String, ?>) getLongPollField(longPollService, "remoteNotificationMessages")).clear();
     }
 
     private static Object getLongPollField(RemoteConfigLongPollService longPollService, String fieldName)

--- a/apollo-plugin/apollo-plugin-log4j2/src/test/java/com/ctrip/framework/apollo/plugin/log4j2/ApolloClientConfigurationFactoryTest.java
+++ b/apollo-plugin/apollo-plugin-log4j2/src/test/java/com/ctrip/framework/apollo/plugin/log4j2/ApolloClientConfigurationFactoryTest.java
@@ -121,12 +121,12 @@ public class ApolloClientConfigurationFactoryTest {
   }
 
   private static void clearApolloCaches() throws Exception {
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configs");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configLocks");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFiles");
-    clearField(ApolloInjector.getInstance(ConfigManager.class), "m_configFileLocks");
-    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "m_factories");
-    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "m_instances");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configs");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configLocks");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFiles");
+    clearField(ApolloInjector.getInstance(ConfigManager.class), "configFileLocks");
+    clearField(ApolloInjector.getInstance(ConfigFactoryManager.class), "factories");
+    clearField(ApolloInjector.getInstance(ConfigRegistry.class), "instances");
   }
 
   private static void clearField(Object instance, String fieldName) throws Exception {


### PR DESCRIPTION
apollo-core and apollo-client carried a legacy Ctrip/C++ (Hungarian notation) field naming convention using m_/s_ prefixes, inconsistent with idiomatic Java. Strip the prefixes across both modules' main and test sources, and update the handful of cross-module reflection lookups (mockserver, log4j2 plugin, config-data, compat-tests) that referenced the old field names by string literal.

## What's the purpose of this PR

XXXXX

## Which issue(s) this PR fixes:
Fixes #

## Brief changelog

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit tests to verify the code.
- [ ] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).
